### PR TITLE
[PBA-4219] Changed all uses of OoyalaSDK headers to switch to umbrell…

### DIFF
--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/ChangeVideoPlayerViewController.m
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/ChangeVideoPlayerViewController.m
@@ -9,9 +9,7 @@
 
 #import "ChangeVideoPlayerViewController.h"
 
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface ChangeVideoPlayerViewController ()
 @property OOOoyalaPlayerViewController *ooyalaPlayerViewController;

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/CustomControlsPlayerViewController.m
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/CustomControlsPlayerViewController.m
@@ -10,9 +10,7 @@
 #import "CustomControlsPlayerViewController.h"
 #import "CustomControlsViewController.h"
 
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 /**
  * This player has code which utilizes our DefaultControlsSource for custom controls.

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/CustomOverlayPlayerViewController.m
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/CustomOverlayPlayerViewController.m
@@ -17,9 +17,7 @@
 #import "CustomControlsViewController.h"
 #import "CustomOverlayView.h"
 
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface CustomOverlayPlayerViewController ()
 @property OOOoyalaPlayerViewController *ooyalaPlayerViewController;

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/InsertAdPlayerViewController.m
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/InsertAdPlayerViewController.m
@@ -9,13 +9,7 @@
 
 #import "InsertAdPlayerViewController.h"
 
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OOManagedAdSpot.h>
-#import <OoyalaSDK/OOManagedAdsPlugin.h>
-#import <OoyalaSDK/OOVASTAdSpot.h>
-#import <OoyalaSDK/OOOoyalaAdSpot.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface InsertAdPlayerViewController ()
 @property OOOoyalaPlayerViewController *ooyalaPlayerViewController;

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/PerformanceProfilingPlayerViewController.m
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/PerformanceProfilingPlayerViewController.m
@@ -5,10 +5,7 @@
 
 #import "PerformanceProfilingPlayerViewController.h"
 
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OOPerformanceMonitorBuilder.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface PerformanceProfilingPlayerViewController ()
 @property (nonatomic) OOOoyalaPlayerViewController *ooyalaPlayerViewController;

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/PlayWithInitialTimePlayerViewController.m
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/PlayWithInitialTimePlayerViewController.m
@@ -9,9 +9,7 @@
 
 #import "PlayWithInitialTimePlayerViewController.h"
 
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface PlayWithInitialTimePlayerViewController ()
 @property OOOoyalaPlayerViewController *ooyalaPlayerViewController;

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/PluginPlayerViewController.m
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/PluginPlayerViewController.m
@@ -10,9 +10,7 @@
 #import "PluginPlayerViewController.h"
 #import "OOSamplePlugin.h"
 
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface PluginPlayerViewController ()
 @property OOOoyalaPlayerViewController *ooyalaPlayerViewController;

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/UnbundledPlayerViewController.m
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/UnbundledPlayerViewController.m
@@ -8,12 +8,7 @@
 
 
 #import "UnbundledPlayerViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OOStream.h>
-#import <OoyalaSDK/OOUnbundledVideo.h>
-#import <OoyalaSDK/OODeliveryTypeConstants.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface UnbundledPlayerViewController ()
 @property (strong, nonatomic) OOOoyalaPlayerViewController *ooyalaPlayerViewController;

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/Controls/CustomControlsView.h
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/Controls/CustomControlsView.h
@@ -6,11 +6,8 @@
 //
 
 #import <UIKit/UIKit.h>
-#import <OoyalaSDK/OOUIProgressSliderIOS7.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import <MediaPlayer/MediaPlayer.h>
-#import <OoyalaSDK/OOPlayPauseButton.h>
-#import <OoyalaSDK/OOClosedCaptionsButton.h>
-#import <OoyalaSDK/OOFullscreenButton.h>
 
 
 @interface CustomControlsView : UIView

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/Controls/CustomControlsView.m
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/Controls/CustomControlsView.m
@@ -8,7 +8,7 @@
 #import "CustomControlsView.h"
 #import "OOImagesIOS7.h"
 #import "OOUIUtils.h"
-#import <OoyalaSDK/iOS7ScrubberSliderFraming.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface CustomControlsView() {
 }

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/Controls/CustomControlsViewController.m
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/Controls/CustomControlsViewController.m
@@ -8,12 +8,7 @@
 #import "CustomControlsViewController.h"
 #import "CustomControlsView.h"
 #import "OOUIUtils.h"
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOUIProgressSliderIOS7.h>
-#import <OoyalaSDK/OOVideo.h>
-#import <OoyalaSDK/OODebugMode.h>
-#import <OoyalaSDK/OOOptions.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface CustomControlsViewController() {
   BOOL wasPlaying;

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/Controls/OOControlsViewController.h
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/Controls/OOControlsViewController.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 #import "CustomControlsView.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @class OOOoyalaPlayer;
 

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/Controls/OOControlsViewController.m
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/Controls/OOControlsViewController.m
@@ -7,9 +7,7 @@
  */
 
 #import <OOControlsViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOVideo.h>
-#import <OoyalaSDK/OOOptions.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import "OOUIUtils.h"
 
 @interface OOUnselectableActivityIndicatorView : UIActivityIndicatorView

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/Controls/OOFullScreenIOS7ControlsView.h
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/Controls/OOFullScreenIOS7ControlsView.h
@@ -7,9 +7,7 @@
 
 #import <UIKit/UIKit.h>
 #import <MediaPlayer/MediaPlayer.h>
-#import <OoyalaSDK/OOClosedCaptionsButton.h>
-#import <OoyalaSDK/OOPlayPauseButton.h>
-#import <OoyalaSDK/OOVideoGravityButton.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @class OOUIProgressSliderIOS7;
 @class OOVolumeView;

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/Controls/OOFullScreenIOS7ControlsView.m
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/Controls/OOFullScreenIOS7ControlsView.m
@@ -7,12 +7,9 @@
  */
 #import <QuartzCore/QuartzCore.h>
 #import "OOFullScreenIOS7ControlsView.h"
-#import <OoyalaSDK/OOTransparentToolbar.h>
-#import <OoyalaSDK/OOUIProgressSliderIOS7.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import "OOImagesIOS7.h"
 #import "OOUIUtils.h"
-#import <OoyalaSDK/iOS7ScrubberSliderFraming.h>
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
 
 @interface OOFullScreenIOS7ControlsView() {
 }

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/Controls/OOFullScreenIOS7ViewController.m
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/Controls/OOFullScreenIOS7ViewController.m
@@ -8,10 +8,7 @@
 #import "OOFullScreenIOS7ViewController.h"
 #import "OOFullScreenIOS7ControlsView.h"
 #import "OOUIUtils.h"
-#import <OoyalaSDK/OOUIProgressSliderIOS7.h>
-#import <OoyalaSDK/OOVideo.h>
-#import <OoyalaSDK/OODebugMode.h>
-#import <OoyalaSDK/OOOptions.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface OOFullScreenIOS7ViewController ()
 

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/OOSampleAdPlayer.h
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/OOSampleAdPlayer.h
@@ -8,9 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import <OoyalaSDK/OOPlayerProtocol.h>
-#import <OoyalaSDK/OOLifeCycle.h>
-#import <OoyalaSDK/OOStateNotifier.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import "OOSampleAdSpot.h"
 
 @interface OOSampleAdPlayer : UILabel <OOLifeCycle, OOPlayerProtocol>

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/OOSampleAdSpot.h
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/OOSampleAdSpot.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <OoyalaSDK/OOAdSpot.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface OOSampleAdSpot : OOAdSpot
 

--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/OOSamplePlugin.h
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Utils/OOSamplePlugin.h
@@ -7,8 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <OoyalaSDK/OOAdPlugin.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface OOSamplePlugin : NSObject <OOAdPlugin>
 

--- a/AnalyticsPluginSampleApp/AnalyticsPluginSampleApp/Players/NielsenPlayerViewController.m
+++ b/AnalyticsPluginSampleApp/AnalyticsPluginSampleApp/Players/NielsenPlayerViewController.m
@@ -5,9 +5,7 @@
  * @copyright  Copyright (c) 2014 Ooyala, Inc. All rights reserved.
  */
 #import "NielsenPlayerViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OOOoyalaError.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import <OoyalaNielsenSDK/OONielsenPlugin.h>
 #import <NielsenAppApi/NielsenAppApi.h>
 

--- a/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
@@ -8,9 +8,7 @@
 
 
 #import "BasicSimplePlayerViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import "AppDelegate.h"
 
 @interface BasicSimplePlayerViewController ()

--- a/ChromecastSampleApp/ChromecastSampleApp/Lists/ChromecastListViewController.m
+++ b/ChromecastSampleApp/ChromecastSampleApp/Lists/ChromecastListViewController.m
@@ -11,8 +11,7 @@
 #import "Utils.h"
 #import "CustomizedMiniControllerView.h"
 #import "ChromecastPlayerSelectionOption.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import <OoyalaCastSDK/OOCastMiniControllerView.h>
 #import <OoyalaCastSDK/OOCastPlayer.h>
 #import <OoyalaCastSDK/OOCastMiniControllerView.h>

--- a/ChromecastSampleApp/ChromecastSampleApp/Players/CastPlaybackView.h
+++ b/ChromecastSampleApp/ChromecastSampleApp/Players/CastPlaybackView.h
@@ -4,7 +4,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import <OoyalaSDK/OOVideo.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface CastPlaybackView : UIImageView
 -(instancetype) init __attribute__((unavailable("init")));

--- a/ChromecastSampleApp/ChromecastSampleApp/Players/PlayerViewController.m
+++ b/ChromecastSampleApp/ChromecastSampleApp/Players/PlayerViewController.m
@@ -7,12 +7,7 @@
 //
 
 #import "PlayerViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOEmbeddedSecureURLGenerator.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OOVideo.h>
-#import <OoyalaSDK/OODebugMode.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import <OoyalaCastSDK/OOCastPlayer.h>
 #import "Utils.h"
 #import "OOCastManagerFetcher.h"

--- a/CompleteSampleApp/CompleteSampleApp/AppDelegate.m
+++ b/CompleteSampleApp/CompleteSampleApp/AppDelegate.m
@@ -8,7 +8,7 @@
 #import "AppDelegate.h"
 
 #import "CompleteSampleAppListViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 @interface AppDelegate () <UINavigationControllerDelegate>
 
 @end

--- a/CompleteSampleApp/CompleteSampleApp/Players/SimplePlayerViewController.m
+++ b/CompleteSampleApp/CompleteSampleApp/Players/SimplePlayerViewController.m
@@ -6,9 +6,7 @@
 //
 
 #import "SimplePlayerViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface SimplePlayerViewController ()
 @property OOOoyalaPlayerViewController *ooyalaPlayerViewController;

--- a/ContentProtectionSampleApp/ContentProtectionSampleApp/Players/AdobePassPlayerViewController.m
+++ b/ContentProtectionSampleApp/ContentProtectionSampleApp/Players/AdobePassPlayerViewController.m
@@ -8,8 +8,7 @@
 
 #import "AdobePassPlayerViewController.h"
 #import "AdobePassViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface AdobePassPlayerViewController () <AdobePassViewControllerDelegate>
 @property NSString *embedCode;

--- a/ContentProtectionSampleApp/ContentProtectionSampleApp/Players/DeviceManagementPlayerViewController.m
+++ b/ContentProtectionSampleApp/ContentProtectionSampleApp/Players/DeviceManagementPlayerViewController.m
@@ -9,11 +9,7 @@
 
 #import "DeviceManagementPlayerViewController.h"
 #import "AdobePassViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OOooyalaError.h>
-#import <OoyalaSDK/OOOptions.h>
-#import <OoyalaSDK/OOEmbeddedSecureURLGenerator.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface DeviceManagementPlayerViewController () <OOEmbedTokenGenerator>
 @property OOOoyalaPlayerViewController *ooyalaPlayerViewController;

--- a/ContentProtectionSampleApp/ContentProtectionSampleApp/Players/FairplayPlayerViewController.m
+++ b/ContentProtectionSampleApp/ContentProtectionSampleApp/Players/FairplayPlayerViewController.m
@@ -1,10 +1,5 @@
 #import "FairplayPlayerViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OOooyalaError.h>
-#import <OoyalaSDK/OOOptions.h>
-#import <OoyalaSDK/OOEmbeddedSecureURLGenerator.h>
-#import <OoyalaSDK/OODebugMode.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 /**
  * This activity illustrates how you configure your application to run Fairplay assets

--- a/ContentProtectionSampleApp/ContentProtectionSampleApp/Players/OoyalaPlayerTokenPlayerViewController.m
+++ b/ContentProtectionSampleApp/ContentProtectionSampleApp/Players/OoyalaPlayerTokenPlayerViewController.m
@@ -9,11 +9,7 @@
 
 #import "OoyalaPlayerTokenPlayerViewController.h"
 #import "AdobePassViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OOooyalaError.h>
-#import <OoyalaSDK/OODebugMode.h>
-#import <OoyalaSDK/OOEmbeddedSecureURLGenerator.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 /**
  * This activity illustrates how you use Ooyala Player Token.

--- a/ContentProtectionSampleApp/ContentProtectionSampleApp/Utils/AdobePassViewController.h
+++ b/ContentProtectionSampleApp/ContentProtectionSampleApp/Utils/AdobePassViewController.h
@@ -7,7 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import <OoyalaSDK/OOEmbedTokenGenerator.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 extern int const PASS_SUCCESS;
 extern int const PASS_FAILURE;

--- a/FreewheelSampleApp/FreewheelSampleApp/Players/FreewheelPlayerViewController.m
+++ b/FreewheelSampleApp/FreewheelSampleApp/Players/FreewheelPlayerViewController.m
@@ -8,9 +8,7 @@
 
 
 #import "FreewheelPlayerViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import <OoyalaFreewheelSDK/OOFreewheelManager.h>
 #import "AppDelegate.h"
 

--- a/IMASampleApp/IMASampleApp/Players/IMACustomConfiguredPlayerViewController.m
+++ b/IMASampleApp/IMASampleApp/Players/IMACustomConfiguredPlayerViewController.m
@@ -8,9 +8,7 @@
 
 
 #import "IMACustomConfiguredPlayerViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import <OoyalaIMASDK/OOIMAManager.h>
 #import "AppDelegate.h"
 

--- a/IMASampleApp/IMASampleApp/Players/IMAPlayerViewController.m
+++ b/IMASampleApp/IMASampleApp/Players/IMAPlayerViewController.m
@@ -8,9 +8,7 @@
 
 
 #import "IMAPlayerViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import <OoyalaIMASDK/OOIMAManager.h>
 #import "AppDelegate.h"
 

--- a/NPAWSampleApp/NPAWSampleApp/Players/NPAWDefaultPlayerViewController.m
+++ b/NPAWSampleApp/NPAWSampleApp/Players/NPAWDefaultPlayerViewController.m
@@ -8,9 +8,7 @@
 
 #import "NPAWDefaultPlayerViewController.h"
 #import <YouboraMedia/Youbora.h>
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface NPAWDefaultPlayerViewController ()
 @property (strong, nonatomic) OOOoyalaPlayerViewController *ooyalaPlayerViewController;

--- a/NPAWSampleApp/NPAWSampleApp/Players/NPAWOptionalMetadataPlayerViewController.m
+++ b/NPAWSampleApp/NPAWSampleApp/Players/NPAWOptionalMetadataPlayerViewController.m
@@ -8,9 +8,9 @@
 
 #import "NPAWOptionalMetadataPlayerViewController.h"
 #import <YouboraMedia/Youbora.h>
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
+#import <OoyalaSDK/OoyalaSDK.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface NPAWOptionalMetadataPlayerViewController ()
 @property (strong, nonatomic) OOOoyalaPlayerViewController *ooyalaPlayerViewController;

--- a/OmnitureSampleApp/iOSOmnitureSampleApp/iOSOmnitureSampleApp/Players/BasicPlayerViewController.m
+++ b/OmnitureSampleApp/iOSOmnitureSampleApp/iOSOmnitureSampleApp/Players/BasicPlayerViewController.m
@@ -7,9 +7,7 @@
 
 #import "BasicPlayerViewController.h"
 #import "PlayerSelectionOption.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import <OoyalaAdobeAnalyticsSDK/OoyalaAdobeAnalyticsSDK.h>
 
 @interface BasicPlayerViewController ()

--- a/OoyalaAPISampleApp/OoyalaAPISampleApp/Lists/DiscoveryListViewController.m
+++ b/OoyalaAPISampleApp/OoyalaAPISampleApp/Lists/DiscoveryListViewController.m
@@ -10,8 +10,7 @@
 #import "PlayerSelectionOption.h"
 #import "ChannelContentTreeDetailViewController.h"
 #import "ChannelContentTreeTableViewCell.h"
-#import <OoyalaSDK/OODiscoveryManager.h>
-#import <OoyalaSDK/OODebugMode.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface DiscoveryListViewController ()
 

--- a/OoyalaAPISampleApp/OoyalaAPISampleApp/Players/ChannelContentTreeDetailViewController.m
+++ b/OoyalaAPISampleApp/OoyalaAPISampleApp/Players/ChannelContentTreeDetailViewController.m
@@ -6,9 +6,7 @@
  */
 
 #import "ChannelContentTreeDetailViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OODebugMode.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface ChannelContentTreeDetailViewController () {
   NSString *embedCode;

--- a/OoyalaAPISampleApp/OoyalaAPISampleApp/Players/ChannelContentTreePlayerViewController.m
+++ b/OoyalaAPISampleApp/OoyalaAPISampleApp/Players/ChannelContentTreePlayerViewController.m
@@ -6,13 +6,7 @@
  */
 
 #import "ChannelContentTreePlayerViewController.h"
-#import <OoyalaSDK/OOOoyalaAPIClient.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OODebugMode.h>
-#import <OoyalaSDK/OOOoyalaError.h>
-#import <OoyalaSDK/OOChannel.h>
-#import <OoyalaSDK/OOVideo.h>
-#import <OoyalaSDK/OOOrderedDictionary.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import "ChannelContentTreeTableViewCell.h"
 #import "ChannelContentTreeDetailViewController.h"
 

--- a/OoyalaSkinSampleApp/OoyalaSkinSampleApp/Players/DefaultSkinPlayerViewController.m
+++ b/OoyalaSkinSampleApp/OoyalaSkinSampleApp/Players/DefaultSkinPlayerViewController.m
@@ -9,10 +9,7 @@
 #import "DefaultSkinPlayerViewController.h"
 #import <OoyalaSkinSDK/OOSkinViewController.h>
 #import <OoyalaSkinSDK/OOSkinOptions.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OOOptions.h>
-#import <OoyalaSDK/OODiscoveryOptions.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface DefaultSkinPlayerViewController ()
 

--- a/OoyalaSkinSampleApp/OoyalaSkinSampleApp/Players/FreewheelPlayerViewController.m
+++ b/OoyalaSkinSampleApp/OoyalaSkinSampleApp/Players/FreewheelPlayerViewController.m
@@ -10,10 +10,7 @@
 #import <OoyalaFreewheelSDK/OOFreewheelManager.h>
 #import <OoyalaSkinSDK/OOSkinViewController.h>
 #import <OoyalaSkinSDK/OOSkinOptions.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OOOptions.h>
-#import <OoyalaSDK/OODiscoveryOptions.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 
 @interface FreewheelPlayerViewController ()

--- a/OoyalaSkinSampleApp/OoyalaSkinSampleApp/Players/IMAPlayerViewController.m
+++ b/OoyalaSkinSampleApp/OoyalaSkinSampleApp/Players/IMAPlayerViewController.m
@@ -10,10 +10,7 @@
 #import <OoyalaIMASDK/OOIMAManager.h>
 #import <OoyalaSkinSDK/OOSkinViewController.h>
 #import <OoyalaSkinSDK/OOSkinOptions.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OOOptions.h>
-#import <OoyalaSDK/OODiscoveryOptions.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface IMAPlayerViewController ()
 @property (nonatomic, retain) OOIMAManager *adsManager;

--- a/OptionsSampleApp/OptionsSampleApp/Players/OptionsViewController.m
+++ b/OptionsSampleApp/OptionsSampleApp/Players/OptionsViewController.m
@@ -7,9 +7,7 @@
 //
 
 #import "OptionsViewController.h"
-#import <OoyalaSDK/OOOptions.h>
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface OptionsViewController () <UITextFieldDelegate>
 

--- a/OptionsSampleApp/OptionsSampleApp/Players/TVRatingsPlayerViewController.m
+++ b/OptionsSampleApp/OptionsSampleApp/Players/TVRatingsPlayerViewController.m
@@ -7,10 +7,7 @@
 //
 
 #import "TVRatingsPlayerViewController.h"
-#import <OoyalaSDK/OOOptions.h>
-#import <OoyalaSDK/OOFCCTVRatingConfiguration.h>
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface TVRatingsPlayerViewController () <UITextFieldDelegate>
 

--- a/PlaybackLab/CocoaPodsSampleApp/CocoaPodsSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/PlaybackLab/CocoaPodsSampleApp/CocoaPodsSampleApp/Players/BasicSimplePlayerViewController.m
@@ -8,9 +8,7 @@
 
 
 #import "BasicSimplePlayerViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface BasicSimplePlayerViewController ()
 @property (strong, nonatomic) OOOoyalaPlayerViewController *ooyalaPlayerViewController;

--- a/PlaybackLab/SwiftSampleApp/SwiftSampleApp/SwiftSampleApp-Bridging-Header.h
+++ b/PlaybackLab/SwiftSampleApp/SwiftSampleApp/SwiftSampleApp-Bridging-Header.h
@@ -9,9 +9,6 @@
 #ifndef SwiftSampleApp_SwiftSampleApp_Bridging_Header_h
 #define SwiftSampleApp_SwiftSampleApp_Bridging_Header_h
 
-#import <OoyalaSDK/OOOoyalaError.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOooyalaPlayerViewController.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 #endif

--- a/PulseSampleApp/PulseSampleApp/Players/PulseManagerViewController.m
+++ b/PulseSampleApp/PulseSampleApp/Players/PulseManagerViewController.m
@@ -13,10 +13,7 @@
 
 #import <OoyalaPulseIntegration/OOPulseManager.h>
 
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OODiscoveryOptions.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import <OoyalaSkinSDK/OOSkinOptions.h>
 #import <OoyalaSkinSDK/OOSkinViewController.h>
 

--- a/SecurePlayerSampleApp/SecurePlayerSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/SecurePlayerSampleApp/SecurePlayerSampleApp/Players/BasicSimplePlayerViewController.m
@@ -8,9 +8,7 @@
 
 
 #import "BasicSimplePlayerViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @interface BasicSimplePlayerViewController ()
 @property (strong, nonatomic) OOOoyalaPlayerViewController *ooyalaPlayerViewController;

--- a/SecurePlayerSampleApp/SecurePlayerSampleApp/Players/SecurePlayerOPTPlayerViewController.m
+++ b/SecurePlayerSampleApp/SecurePlayerSampleApp/Players/SecurePlayerOPTPlayerViewController.m
@@ -6,11 +6,7 @@
  */
 
 #import "SecurePlayerOPTPlayerViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OOStreamPlayer.h>
-#import <OoyalaSDK/OOooyalaError.h>
-#import <OoyalaSDK/OOEmbeddedSecureURLGenerator.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import <OoyalaSecurePlayerSDK/OOOoyalaSecurePlayerSDK.h>
 
 /**

--- a/SecurePlayerSampleApp/SecurePlayerSampleApp/Players/SecurePlayerPlayerViewController.m
+++ b/SecurePlayerSampleApp/SecurePlayerSampleApp/Players/SecurePlayerPlayerViewController.m
@@ -7,10 +7,7 @@
 
 
 #import "SecurePlayerPlayerViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OOStreamPlayer.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import <OoyalaSecurePlayerSDK/OOOoyalaSecurePlayerSDK.h>
 
 #import "PlayerSelectionOption.h" 

--- a/SecurePlayerSampleApp/SecurePlayerSampleApp/Players/SecurePlayerPrePersonalizedPlayerViewController.m
+++ b/SecurePlayerSampleApp/SecurePlayerSampleApp/Players/SecurePlayerPrePersonalizedPlayerViewController.m
@@ -7,10 +7,7 @@
 
 
 #import "SecurePlayerPrePersonalizedPlayerViewController.h"
-#import <OoyalaSDK/OOOoyalaPlayerViewController.h>
-#import <OoyalaSDK/OOOoyalaPlayer.h>
-#import <OoyalaSDK/OOPlayerDomain.h>
-#import <OoyalaSDK/OOStreamPlayer.h>
+#import <OoyalaSDK/OoyalaSDK.h>
 #import <OoyalaSecurePlayerSDK/OOOoyalaSecurePlayerSDK.h>
 #import <OoyalaSecurePlayerSDK/OOSecurePlayerDrmWorkflow.h>
 #import "PlayerSelectionOption.h" 


### PR DESCRIPTION
…a header

used  grep -rl "#import <OoyalaSDK/.*" ./* |  xargs sed -i "" 's/#import <OoyalaSDK.*/#import <OoyalaSDK\/OoyalaSDK.h>/g' and cleaned up multiple replacements manually
