### PR TITLE
[PBA-4446] Freewheel with SSL enabled

### DIFF
--- a/FreewheelSampleApp/FreewheelSampleApp/Players/FreewheelPlayerViewController.m
+++ b/FreewheelSampleApp/FreewheelSampleApp/Players/FreewheelPlayerViewController.m
@@ -68,7 +68,7 @@
 
   NSMutableDictionary *fwParameters = [[NSMutableDictionary alloc] init];
   //[fwParameters setObject:@"90750" forKey:@"fw_ios_mrm_network_id"];
-  [fwParameters setObject:@"http://g1.v.fwmrm.net/" forKey:@"fw_ios_ad_server"];
+  [fwParameters setObject:@"https://g1.v.fwmrm.net/" forKey:@"fw_ios_ad_server"];
   [fwParameters setObject:@"90750:ooyala_ios" forKey:@"fw_ios_player_profile"];
   [fwParameters setObject:@"channel=TEST;subchannel=TEST;section=TEST;mode=online;player=ooyala;beta=n" forKey:@"FRMSegment"];
   //[fwParameters setObject:@"ooyala_test_site_section" forKey:@"fw_ios_site_section_id"];

--- a/OoyalaSkinSampleApp/OoyalaSkinSampleApp/Players/FreewheelPlayerViewController.m
+++ b/OoyalaSkinSampleApp/OoyalaSkinSampleApp/Players/FreewheelPlayerViewController.m
@@ -72,7 +72,7 @@
 
   NSMutableDictionary *fwParameters = [[NSMutableDictionary alloc] init];
   //[fwParameters setObject:@"90750" forKey:@"fw_ios_mrm_network_id"];
-  [fwParameters setObject:@"http://g1.v.fwmrm.net/" forKey:@"fw_ios_ad_server"];
+  [fwParameters setObject:@"https://g1.v.fwmrm.net/" forKey:@"fw_ios_ad_server"];
   [fwParameters setObject:@"90750:ooyala_ios" forKey:@"fw_ios_player_profile"];
   [fwParameters setObject:@"channel=TEST;subchannel=TEST;section=TEST;mode=online;player=ooyala;beta=n" forKey:@"FRMSegment"];
   //[fwParameters setObject:@"ooyala_test_site_section" forKey:@"fw_ios_site_section_id"];


### PR DESCRIPTION
Freewheel is now ready for Apple ATS. I guess they made changes to their code and now we can use https as the server and we get the ads correctly :) I tested in both simulator and a real device and it worked.

If you want to test with Charles you need to install Charles SSL certificates in the testing devices. You can talk to me if you're interested in debugging with Charles.
