### PR TITLE
[PBA-4447] Enable ssl for Adobe Analytics

### DIFF
--- a/OmnitureSampleApp/iOSOmnitureSampleApp/iOSOmnitureSampleApp/ADBMobileConfig.json
+++ b/OmnitureSampleApp/iOSOmnitureSampleApp/iOSOmnitureSampleApp/ADBMobileConfig.json
@@ -11,7 +11,7 @@
   "analytics": {
     "rsids": "[INSERT YOUR ID HERE]",
     "server": "[INSERT YOUR SERVER HERE]",
-    "ssl": false,
+    "ssl": true,
     "offlineEnabled": false,
     "lifecycleTimeout": 300,
     "privacyDefault": "optedin",


### PR DESCRIPTION
This is all we need to do in ios-sample-apps to enable ssl and make our Adobe Analytics integration ATS compliant. We still need to test if it works.
