### PR TITLE
[PBA-4679] Change playerControlsEnabled calls

### DIFF
--- a/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Lists/VideoTableViewController.m
+++ b/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Lists/VideoTableViewController.m
@@ -43,11 +43,12 @@
                                                                 domain:@"http://www.ooyala.com"
                                                              segueName:@"fullscreenSegue"]];
 
-  [self.options addObject:[[PlayerSelectionOption alloc] initWithTitle:@"Inline Player"
-                                                             embedCode:@"Y1ZHB1ZDqfhCPjYYRbCEOz0GR8IsVRm1"
-                                                                 pcode:@"c0cTkxOqALQviQIGAHWY5hP0q9gU"
-                                                                domain:@"http://www.ooyala.com"
-                                                             segueName:@"childSegue"]];
+  // Read the comments in ChildPlayerViewController.h to know what this example is for
+//  [self.options addObject:[[PlayerSelectionOption alloc] initWithTitle:@"Inline Player"
+//                                                             embedCode:@"Y1ZHB1ZDqfhCPjYYRbCEOz0GR8IsVRm1"
+//                                                                 pcode:@"c0cTkxOqALQviQIGAHWY5hP0q9gU"
+//                                                                domain:@"http://www.ooyala.com"
+//                                                             segueName:@"childSegue"]];
 
   [self.options addObject:[[PlayerSelectionOption alloc] initWithTitle:@"Player Token (Unconfigured)"
                                                              embedCode:@"0yMjJ2ZDosUnthiqqIM3c8Eb8Ilx5r52"
@@ -60,11 +61,13 @@
                                                                  pcode:@"c0cTkxOqALQviQIGAHWY5hP0q9gU"
                                                                 domain:@"http://www.ooyala.com"
                                                              segueName:@"fairplaySegue"]];
+  
   [self.options addObject:[[PlayerSelectionOption alloc] initWithTitle:@"Fairplay Main Profile (Unconfigured)"
                                                              embedCode:@"cycDhnMzE66D5DPpy3oIOzli1HVMoYnJ"
                                                                  pcode:@"c0cTkxOqALQviQIGAHWY5hP0q9gU"
                                                                 domain:@"http://www.ooyala.com"
                                                              segueName:@"fairplaySegue"]];
+  
   [self.options addObject:[[PlayerSelectionOption alloc] initWithTitle:@"Fairplay High Profile (Unconfigured)"
                                                              embedCode:@"d2dzhnMzE6h-LTaIavPD5k2eqLeCTMC5"
                                                                  pcode:@"c0cTkxOqALQviQIGAHWY5hP0q9gU"

--- a/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/ChildPlayerViewController.h
+++ b/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/ChildPlayerViewController.h
@@ -4,6 +4,13 @@
 //
 //  Copyright © 2016 Ooyala. All rights reserved.
 //
+// This example shows shows a use case in which you want to show the player next to
+// other UI in the screen, so the player will not be in fullscreen mode taking all
+// your screen space, but it will be sharing the UI with other elements which could
+// be actionable too, like buttons.
+//
+// This is not a verified use case by Ooyala and cause extrange behavior for the player,
+// but we provide the example in case you want to use it.
 
 #import <UIKit/UIKit.h>
 #import "AbstractPlayerViewController.h"

--- a/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/ChildPlayerViewController.m
+++ b/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/ChildPlayerViewController.m
@@ -31,6 +31,7 @@
   // Create Ooyala ViewController
   OOOoyalaPlayer *player = [[OOOoyalaPlayer alloc] initWithPcode:self.pcode domain:[[OOPlayerDomain alloc] initWithString:self.playerDomain]];
   self.ooyalaPlayerViewController = [[OOOoyalaTVPlayerViewController alloc] initWithPlayer:player];
+  self.ooyalaPlayerViewController.playbackControlsEnabled = NO;
   
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(notificationHandler:)

--- a/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/FullscreenPlayerViewController.m
+++ b/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/FullscreenPlayerViewController.m
@@ -25,7 +25,6 @@
   self.pcode = self.option.pcode;
   self.playerDomain = self.option.domain;
 
-  self.playbackControlsEnabled = YES;
   self.player = [[OOOoyalaPlayer alloc] initWithPcode:self.pcode domain:[[OOPlayerDomain alloc] initWithString:self.playerDomain]];
   
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(notificationHandler:) name:nil object:self.player];

--- a/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/OoyalaPlayerTokenPlayerViewController.m
+++ b/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/OoyalaPlayerTokenPlayerViewController.m
@@ -13,7 +13,7 @@
 #import <OoyalaSDK/OOEmbeddedSecureURLGenerator.h>
 #import "PlayerSelectionOption.h"
 
-@interface OoyalaPlayerTokenPlayerViewController ()
+@interface OoyalaPlayerTokenPlayerViewController () <OOEmbedTokenGenerator>
 
 @property (nonatomic, strong) NSString *embedCode;
 @property (nonatomic, strong) NSString *pcode;


### PR DESCRIPTION
This depends on the new SDK 4.19.0_RC3, which should enable player controls by default, so we no longer need to call.

But I found out that for the childViewController the UI is weird, so we'll need to fix that too. That's why I'm disabling the controls for that VC.
