### PR TITLE
[PBA-5530] Change integration instructions

### DIFF
--- a/PlaybackLab/TVOSSampleApp/README.md
+++ b/PlaybackLab/TVOSSampleApp/README.md
@@ -9,5 +9,6 @@ This app requires the tvOS Pulse SDK library to run.  In order to get this you m
 1. Go to [help.ooyala.com/downloads](help.ooyala.com/downloads)
 1. Download "tvOS 2.x SDK framework"
 1. Take the resulting Pulse_tvOS.framework and paste it in `TVOSSampleApp/VendorLibraries
-1. In Xcode, add Pulse_tvOS.framework to Linked Frameworks and Libraries, and Embedded Binaries of the TVOSSampleApp target
+1. In Xcode, add Pulse_tvOS.framework to Linked Frameworks and Libraries of the TVOSSampleApp target
+1. In Xcode, add Pulse_tvOS.framework to Embedded Binaries of the TVOSSampleApp target
 1. Run the application

--- a/PlaybackLab/TVOSSampleApp/README.md
+++ b/PlaybackLab/TVOSSampleApp/README.md
@@ -1,6 +1,6 @@
 # TVOSSampleApp
 
-This App is a work-in-progress project which demostrates the feature capabilities of our tvOS integration.
+This App is a work-in-progress project which demonstrates the feature capabilities of our tvOS integration.
 
 While our tvOS integration cannot use the same Skin UI as our Android and iOS libraries, our tvOS integration uses an open sourced UI that is in the [native-skin github repo](https://github.com/ooyala/native-skin).
 
@@ -8,7 +8,6 @@ This app requires the tvOS Pulse SDK library to run.  In order to get this you m
 
 1. Go to [help.ooyala.com/downloads](help.ooyala.com/downloads)
 1. Download "tvOS 2.x SDK framework"
-1. Take the resulting Pulse-tvos.framework and paste it in `TVOSSampleApp/VendorLibraries
-1. Rename Pulse-tvos.framework to Pulse.framework
-1. Within the Pulse.framework folder, Rename Pulse-tvos to Pulse
+1. Take the resulting Pulse_tvOS.framework and paste it in `TVOSSampleApp/VendorLibraries
+1. In Xcode, add Pulse_tvOS.framework to Linked Frameworks and Libraries, and Embedded Binaries of the TVOSSampleApp target
 1. Run the application

--- a/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/PulsePlayerViewController.m
+++ b/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/PulsePlayerViewController.m
@@ -8,7 +8,7 @@
 #import <OoyalaSDK/OOOoyalaPlayer.h>
 #import <OoyalaSDK/OOPlayerDomain.h>
 #import <OoyalaPulseIntegration/OoyalaPulseIntegration.h>
-#import <Pulse/Pulse.h>
+#import <Pulse_tvOS/Pulse.h>
 
 #import "PulsePlayerViewController.h"
 #import "PulseLibraryOption.h"


### PR DESCRIPTION
I tested adding the Pulse_tvOS.framework into the app and it only works if you add it to the Embedded Binaries too, not just only Linked Frameworks and Libraries. I’m not adding the Pulse_tvOS.framework here because we still ask people to download it from the Ooyala site.