### PR TITLE
[PLAYER-2030] Update OOPulseManagerDelegate methods 

### DIFF
--- a/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/PulsePlayerViewController.m
+++ b/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/PulsePlayerViewController.m
@@ -57,8 +57,8 @@ NSString *const PLAYER_DOMAIN = @"http://www.ooyala.com";
 - (id<OOPulseSession>)pulseManager:(OOPulseManager *)manager
              createSessionForVideo:(OOVideo *)video
                      withPulseHost:(NSString *)pulseHost
-                   contentMetadata:(VPContentMetadata *)contentMetadata
-                   requestSettings:(VPRequestSettings *)requestSettings
+                   contentMetadata:(OOContentMetadata *)contentMetadata
+                   requestSettings:(OORequestSettings *)requestSettings
 {
   // Here we assume a landscape orientation for video playback
   requestSettings.width = (NSInteger)MAX(self.view.frame.size.width, self.view.frame.size.height);


### PR DESCRIPTION
The latest version of the PulseSDK for tvOS updated the methods signature we use in the sample app. 

Needed to update the methods with the correct arguments.