### PR TITLE
[PLAYER-3059] Add secureURLGenerator option for GeoBlocking assets

### DIFF
--- a/OoyalaSkinSampleApp/OoyalaSkinSampleApp/Players/GeoblockingSkinViewController.m
+++ b/OoyalaSkinSampleApp/OoyalaSkinSampleApp/Players/GeoblockingSkinViewController.m
@@ -65,6 +65,8 @@ AppDelegate *appDel;
   
   // Create Ooyala ViewController
   OOOptions *options = [OOOptions new];
+  // Currently needed for Fairplay
+  options.secureURLGenerator = [[OOEmbeddedSecureURLGenerator alloc] initWithAPIKey:self.apiKey secret:self.secretKey];
   OOOoyalaPlayer *ooyalaPlayer = [[OOOoyalaPlayer alloc] initWithPcode:self.pcode
                                                                 domain:[[OOPlayerDomain alloc] initWithString:self.playerDomain] embedTokenGenerator:self
                                                                options:options];


### PR DESCRIPTION
Fairplay needs to have this object. Otherwise it doesn't work. We might want to change this logic in the SDK but this is how it currently works.