### PR TITLE
[PLAYER-4099] Fix UI for iPads (Analytics)

### DIFF
--- a/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Base.lproj/Main.storyboard
+++ b/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ylV-wG-glq">
-    <device id="ipad9_7" orientation="portrait">
+    <device id="ipad9_7" orientation="landscape">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -14,34 +14,34 @@
             <objects>
                 <tableViewController id="ldA-SG-uTe" customClass="AssetListViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="75" sectionHeaderHeight="28" sectionFooterHeight="28" id="1HU-KU-xK6">
-                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="detailButton" indentationWidth="10" reuseIdentifier="option cell" rowHeight="75" id="qAu-yu-Spi" customClass="OptionTableViewCell">
-                                <rect key="frame" x="0.0" y="28" width="768" height="75"/>
+                                <rect key="frame" x="0.0" y="28" width="1024" height="75"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="qAu-yu-Spi" id="VYV-db-hBq">
-                                    <rect key="frame" x="0.0" y="0.0" width="716" height="74.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="972" height="74.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="240" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="nCI-kB-AnS">
-                                            <rect key="frame" x="20" y="11" width="688" height="53"/>
+                                            <rect key="frame" x="20" y="11" width="944" height="53"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" verticalCompressionResistancePriority="500" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9oY-ft-mBZ">
-                                                    <rect key="frame" x="0.0" y="0.0" width="688" height="21"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="944" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="751" verticalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7eN-OZ-GpE">
-                                                    <rect key="frame" x="0.0" y="29" width="688" height="14.5"/>
+                                                    <rect key="frame" x="0.0" y="29" width="944" height="14.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progressViewStyle="bar" translatesAutoresizingMaskIntoConstraints="NO" id="p1G-VK-JFe">
-                                                    <rect key="frame" x="0.0" y="51.5" width="688" height="2.5"/>
+                                                    <rect key="frame" x="0.0" y="51.5" width="944" height="2.5"/>
                                                     <color key="trackTintColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                 </progressView>
                                             </subviews>
@@ -82,37 +82,37 @@
                         <viewControllerLayoutGuide type="bottom" id="dpb-oe-6hU"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="gOw-vW-fA4">
-                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="bIR-Nf-UA5">
-                                <rect key="frame" x="20" y="70" width="728" height="954"/>
+                                <rect key="frame" x="20" y="70" width="984" height="698"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1rh-N5-OVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="728" height="409.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="984" height="369"/>
                                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vqN-n5-ecd">
-                                        <rect key="frame" x="0.0" y="409.5" width="728" height="544.5"/>
+                                        <rect key="frame" x="0.0" y="369" width="984" height="329"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="State of the Asset" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZXs-My-WiR">
-                                                <rect key="frame" x="10" y="10" width="708" height="24"/>
+                                                <rect key="frame" x="10" y="10" width="964" height="24"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JjF-2Y-B9C">
-                                                <rect key="frame" x="10" y="44" width="708" height="30"/>
+                                                <rect key="frame" x="10" y="44" width="964" height="30"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yrg-Qw-Cm3">
-                                                        <rect key="frame" x="0.0" y="0.0" width="354" height="30"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="482" height="30"/>
                                                         <state key="normal" title="Play Online Video"/>
                                                         <connections>
                                                             <action selector="playOnline" destination="Hvu-ub-zep" eventType="touchUpInside" id="z6W-DN-5bA"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GE5-E2-pnt">
-                                                        <rect key="frame" x="354" y="0.0" width="354" height="30"/>
+                                                        <rect key="frame" x="482" y="0.0" width="482" height="30"/>
                                                         <state key="normal" title="Play Offline Video"/>
                                                         <connections>
                                                             <action selector="playOffline" destination="Hvu-ub-zep" eventType="touchUpInside" id="deV-a0-LtM"/>
@@ -125,7 +125,7 @@
                                                 </constraints>
                                             </stackView>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="pkX-Vz-MdJ">
-                                                <rect key="frame" x="10" y="124" width="708" height="410.5"/>
+                                                <rect key="frame" x="10" y="84" width="964" height="235"/>
                                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -140,14 +140,14 @@
                                             <constraint firstItem="JjF-2Y-B9C" firstAttribute="top" secondItem="ZXs-My-WiR" secondAttribute="bottom" constant="10" id="91o-Ri-Ppz"/>
                                             <constraint firstItem="JjF-2Y-B9C" firstAttribute="leading" secondItem="vqN-n5-ecd" secondAttribute="leading" constant="10" id="AAn-l2-V2p"/>
                                             <constraint firstAttribute="trailing" secondItem="ZXs-My-WiR" secondAttribute="trailing" constant="10" id="WpY-Gf-9rX"/>
-                                            <constraint firstItem="pkX-Vz-MdJ" firstAttribute="top" secondItem="JjF-2Y-B9C" secondAttribute="bottom" constant="50" id="cdr-hK-t7M"/>
+                                            <constraint firstItem="pkX-Vz-MdJ" firstAttribute="top" secondItem="JjF-2Y-B9C" secondAttribute="bottom" constant="10" id="cdr-hK-t7M"/>
                                             <constraint firstItem="ZXs-My-WiR" firstAttribute="top" secondItem="vqN-n5-ecd" secondAttribute="top" constant="10" id="ePY-kY-SJl"/>
                                             <constraint firstAttribute="trailing" secondItem="JjF-2Y-B9C" secondAttribute="trailing" constant="10" id="hfk-GP-IIX"/>
                                         </constraints>
                                     </view>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="vqN-n5-ecd" firstAttribute="width" secondItem="1rh-N5-OVq" secondAttribute="height" multiplier="16:9" id="yhr-fh-Nk6"/>
+                                    <constraint firstItem="vqN-n5-ecd" firstAttribute="width" secondItem="1rh-N5-OVq" secondAttribute="height" multiplier="16:6" id="yhr-fh-Nk6"/>
                                 </constraints>
                             </stackView>
                         </subviews>
@@ -176,7 +176,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="ylV-wG-glq" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="uKw-Cg-LGP">
-                        <rect key="frame" x="0.0" y="20" width="768" height="50"/>
+                        <rect key="frame" x="0.0" y="20" width="1024" height="50"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Base.lproj/Main.storyboard
+++ b/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ylV-wG-glq">
-    <device id="retina4_7" orientation="portrait">
+    <device id="ipad9_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -14,34 +14,34 @@
             <objects>
                 <tableViewController id="ldA-SG-uTe" customClass="AssetListViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="75" sectionHeaderHeight="28" sectionFooterHeight="28" id="1HU-KU-xK6">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="detailButton" indentationWidth="10" reuseIdentifier="option cell" rowHeight="75" id="qAu-yu-Spi" customClass="OptionTableViewCell">
-                                <rect key="frame" x="0.0" y="28" width="375" height="75"/>
+                                <rect key="frame" x="0.0" y="28" width="768" height="75"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="qAu-yu-Spi" id="VYV-db-hBq">
-                                    <rect key="frame" x="0.0" y="0.0" width="327" height="74.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="716" height="74.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="240" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="nCI-kB-AnS">
-                                            <rect key="frame" x="16" y="11" width="303" height="53"/>
+                                            <rect key="frame" x="20" y="11" width="688" height="53"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" verticalCompressionResistancePriority="500" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9oY-ft-mBZ">
-                                                    <rect key="frame" x="0.0" y="0.0" width="303" height="21"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="688" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="751" verticalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7eN-OZ-GpE">
-                                                    <rect key="frame" x="0.0" y="29" width="303" height="14.5"/>
+                                                    <rect key="frame" x="0.0" y="29" width="688" height="14.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progressViewStyle="bar" translatesAutoresizingMaskIntoConstraints="NO" id="p1G-VK-JFe">
-                                                    <rect key="frame" x="0.0" y="51.5" width="303" height="2.5"/>
+                                                    <rect key="frame" x="0.0" y="51.5" width="688" height="2.5"/>
                                                     <color key="trackTintColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                 </progressView>
                                             </subviews>
@@ -82,95 +82,88 @@
                         <viewControllerLayoutGuide type="bottom" id="dpb-oe-6hU"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="gOw-vW-fA4">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iyG-lp-2kb">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="bIR-Nf-UA5">
+                                <rect key="frame" x="20" y="70" width="728" height="954"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="z8P-u8-fWG">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="277.5"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1rh-N5-OVq">
+                                        <rect key="frame" x="0.0" y="0.0" width="728" height="409.5"/>
+                                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vqN-n5-ecd">
+                                        <rect key="frame" x="0.0" y="409.5" width="728" height="544.5"/>
                                         <subviews>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="58a-b7-LP6">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="211"/>
-                                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" secondItem="58a-b7-LP6" secondAttribute="height" multiplier="16:9" id="sGf-Im-Nlg"/>
-                                                </constraints>
-                                            </view>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="State: " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Ue-mm-6LK">
-                                                <rect key="frame" x="163" y="219" width="49.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="State of the Asset" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZXs-My-WiR">
+                                                <rect key="frame" x="10" y="10" width="708" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RLR-X6-Hoc">
-                                                <rect key="frame" x="0.0" y="247.5" width="375" height="30"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JjF-2Y-B9C">
+                                                <rect key="frame" x="10" y="44" width="708" height="30"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Mqi-Ql-KuQ">
-                                                        <rect key="frame" x="8" y="0.0" width="114" height="30"/>
-                                                        <state key="normal" title="Set Online Video"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yrg-Qw-Cm3">
+                                                        <rect key="frame" x="0.0" y="0.0" width="354" height="30"/>
+                                                        <state key="normal" title="Play Online Video"/>
                                                         <connections>
-                                                            <action selector="playOnline" destination="Hvu-ub-zep" eventType="touchUpInside" id="g6J-yh-Oc7"/>
+                                                            <action selector="playOnline" destination="Hvu-ub-zep" eventType="touchUpInside" id="z6W-DN-5bA"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="v0z-yC-Pah">
-                                                        <rect key="frame" x="251" y="0.0" width="116" height="30"/>
-                                                        <state key="normal" title="Set Offline Video"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GE5-E2-pnt">
+                                                        <rect key="frame" x="354" y="0.0" width="354" height="30"/>
+                                                        <state key="normal" title="Play Offline Video"/>
                                                         <connections>
-                                                            <action selector="playOffline" destination="Hvu-ub-zep" eventType="touchUpInside" id="OqE-u5-gKK"/>
+                                                            <action selector="playOffline" destination="Hvu-ub-zep" eventType="touchUpInside" id="deV-a0-LtM"/>
                                                         </connections>
                                                     </button>
                                                 </subviews>
-                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="trailing" secondItem="v0z-yC-Pah" secondAttribute="trailing" constant="8" id="CtW-Kp-bCP"/>
-                                                    <constraint firstItem="v0z-yC-Pah" firstAttribute="top" secondItem="RLR-X6-Hoc" secondAttribute="top" id="GkB-za-Kdl"/>
-                                                    <constraint firstItem="Mqi-Ql-KuQ" firstAttribute="top" secondItem="RLR-X6-Hoc" secondAttribute="top" id="H43-y3-nqF"/>
-                                                    <constraint firstAttribute="bottom" secondItem="v0z-yC-Pah" secondAttribute="bottom" id="HIV-WO-kO8"/>
-                                                    <constraint firstAttribute="bottom" secondItem="Mqi-Ql-KuQ" secondAttribute="bottom" id="e15-VW-THd"/>
-                                                    <constraint firstAttribute="height" constant="30" id="pTw-9I-Qov"/>
-                                                    <constraint firstItem="Mqi-Ql-KuQ" firstAttribute="leading" secondItem="RLR-X6-Hoc" secondAttribute="leading" constant="8" id="ygq-xm-Aem"/>
+                                                    <constraint firstItem="yrg-Qw-Cm3" firstAttribute="width" secondItem="GE5-E2-pnt" secondAttribute="width" id="F92-ye-Iha"/>
+                                                    <constraint firstAttribute="height" constant="30" id="fAh-lU-q7Q"/>
                                                 </constraints>
-                                            </view>
+                                            </stackView>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="pkX-Vz-MdJ">
+                                                <rect key="frame" x="10" y="124" width="708" height="410.5"/>
+                                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
                                         </subviews>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstItem="58a-b7-LP6" firstAttribute="leading" secondItem="z8P-u8-fWG" secondAttribute="leading" id="5p7-Lw-ESN"/>
-                                            <constraint firstItem="RLR-X6-Hoc" firstAttribute="leading" secondItem="z8P-u8-fWG" secondAttribute="leading" id="99M-Cj-aQ2"/>
-                                            <constraint firstAttribute="trailing" secondItem="58a-b7-LP6" secondAttribute="trailing" id="Hne-Dx-plH"/>
-                                            <constraint firstAttribute="trailing" secondItem="RLR-X6-Hoc" secondAttribute="trailing" id="x3l-on-SJV"/>
+                                            <constraint firstItem="pkX-Vz-MdJ" firstAttribute="leading" secondItem="vqN-n5-ecd" secondAttribute="leading" constant="10" id="5gf-Lg-cse"/>
+                                            <constraint firstAttribute="trailing" secondItem="pkX-Vz-MdJ" secondAttribute="trailing" constant="10" id="6HZ-aI-ubg"/>
+                                            <constraint firstAttribute="bottom" secondItem="pkX-Vz-MdJ" secondAttribute="bottom" constant="10" id="6Xp-fv-9J1"/>
+                                            <constraint firstItem="ZXs-My-WiR" firstAttribute="leading" secondItem="vqN-n5-ecd" secondAttribute="leading" constant="10" id="7Yb-mF-JRW"/>
+                                            <constraint firstItem="JjF-2Y-B9C" firstAttribute="top" secondItem="ZXs-My-WiR" secondAttribute="bottom" constant="10" id="91o-Ri-Ppz"/>
+                                            <constraint firstItem="JjF-2Y-B9C" firstAttribute="leading" secondItem="vqN-n5-ecd" secondAttribute="leading" constant="10" id="AAn-l2-V2p"/>
+                                            <constraint firstAttribute="trailing" secondItem="ZXs-My-WiR" secondAttribute="trailing" constant="10" id="WpY-Gf-9rX"/>
+                                            <constraint firstItem="pkX-Vz-MdJ" firstAttribute="top" secondItem="JjF-2Y-B9C" secondAttribute="bottom" constant="50" id="cdr-hK-t7M"/>
+                                            <constraint firstItem="ZXs-My-WiR" firstAttribute="top" secondItem="vqN-n5-ecd" secondAttribute="top" constant="10" id="ePY-kY-SJl"/>
+                                            <constraint firstAttribute="trailing" secondItem="JjF-2Y-B9C" secondAttribute="trailing" constant="10" id="hfk-GP-IIX"/>
                                         </constraints>
-                                    </stackView>
-                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H1t-JE-UW2">
-                                        <rect key="frame" x="8" y="286" width="359" height="310"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                    </textView>
+                                    </view>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="bottom" secondItem="z8P-u8-fWG" secondAttribute="bottom" id="HdO-Qb-icV"/>
-                                    <constraint firstItem="z8P-u8-fWG" firstAttribute="width" secondItem="iyG-lp-2kb" secondAttribute="width" id="RYY-6L-niI"/>
-                                    <constraint firstAttribute="trailing" secondItem="z8P-u8-fWG" secondAttribute="trailing" id="Y4t-l1-JS0"/>
-                                    <constraint firstItem="z8P-u8-fWG" firstAttribute="leading" secondItem="iyG-lp-2kb" secondAttribute="leading" id="cOM-Cx-Zca"/>
-                                    <constraint firstItem="z8P-u8-fWG" firstAttribute="top" secondItem="iyG-lp-2kb" secondAttribute="top" id="ypd-CO-k5f"/>
+                                    <constraint firstItem="vqN-n5-ecd" firstAttribute="width" secondItem="1rh-N5-OVq" secondAttribute="height" multiplier="16:9" id="yhr-fh-Nk6"/>
                                 </constraints>
-                            </scrollView>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="iyG-lp-2kb" secondAttribute="trailing" id="QUI-GW-egU"/>
-                            <constraint firstItem="dpb-oe-6hU" firstAttribute="top" secondItem="iyG-lp-2kb" secondAttribute="bottom" id="enm-kn-UqJ"/>
-                            <constraint firstItem="iyG-lp-2kb" firstAttribute="leading" secondItem="gOw-vW-fA4" secondAttribute="leading" id="hgC-tj-DcJ"/>
-                            <constraint firstItem="iyG-lp-2kb" firstAttribute="top" secondItem="gOw-vW-fA4" secondAttribute="top" id="qWf-Xd-cWd"/>
+                            <constraint firstItem="bIR-Nf-UA5" firstAttribute="leading" secondItem="gOw-vW-fA4" secondAttribute="leadingMargin" id="8Ad-md-a8K"/>
+                            <constraint firstItem="bIR-Nf-UA5" firstAttribute="top" secondItem="9Uu-aY-cAC" secondAttribute="bottom" id="Idn-Ib-gWs"/>
+                            <constraint firstItem="dpb-oe-6hU" firstAttribute="top" secondItem="bIR-Nf-UA5" secondAttribute="bottom" id="Oh9-AH-iVQ"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="bIR-Nf-UA5" secondAttribute="trailing" id="cYX-Nd-3ki"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="analyticsData" destination="H1t-JE-UW2" id="8SY-b2-rqc"/>
-                        <outlet property="playOfflineButton" destination="v0z-yC-Pah" id="rCw-r2-AZk"/>
-                        <outlet property="playerView" destination="58a-b7-LP6" id="IHl-O9-hmt"/>
-                        <outlet property="stateLabel" destination="8Ue-mm-6LK" id="i1g-Qy-GBd"/>
+                        <outlet property="analyticsData" destination="pkX-Vz-MdJ" id="psV-Ty-kfg"/>
+                        <outlet property="playOfflineButton" destination="GE5-E2-pnt" id="kBu-mw-hMk"/>
+                        <outlet property="playerView" destination="1rh-N5-OVq" id="DV1-Zo-gc4"/>
+                        <outlet property="stateLabel" destination="ZXs-My-WiR" id="Qjp-qh-Fzn"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6QW-DQ-dg9" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -183,7 +176,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="ylV-wG-glq" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="uKw-Cg-LGP">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="768" height="50"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Info.plist
+++ b/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Info.plist
@@ -25,6 +25,15 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>UIAppFonts</key>
+	<array>
+		<string>ooyala-slick-type.ttf</string>
+		<string>alice.ttf</string>
+		<string>Roboto-Regular.ttf</string>
+		<string>Roboto-Bold.ttf</string>
+		<string>RobotoCondensed-Regular.ttf</string>
+		<string>RobotoCondensed-Bold.ttf</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -36,24 +45,10 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>UIAppFonts</key>
-	<array>
-		<string>ooyala-slick-type.ttf</string>
-		<string>alice.ttf</string>
-		<string>Roboto-Regular.ttf</string>
-		<string>Roboto-Bold.ttf</string>
-		<string>RobotoCondensed-Regular.ttf</string>
-		<string>RobotoCondensed-Bold.ttf</string>
 	</array>
 	<key>VolumeThumbImage</key>
 	<string>VolumeThumb</string>

--- a/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Info.plist
+++ b/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Info.plist
@@ -25,15 +25,6 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
-	<key>UIAppFonts</key>
-	<array>
-		<string>ooyala-slick-type.ttf</string>
-		<string>alice.ttf</string>
-		<string>Roboto-Regular.ttf</string>
-		<string>Roboto-Bold.ttf</string>
-		<string>RobotoCondensed-Regular.ttf</string>
-		<string>RobotoCondensed-Bold.ttf</string>
-	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -45,10 +36,24 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIAppFonts</key>
+	<array>
+		<string>ooyala-slick-type.ttf</string>
+		<string>alice.ttf</string>
+		<string>Roboto-Regular.ttf</string>
+		<string>Roboto-Bold.ttf</string>
+		<string>RobotoCondensed-Regular.ttf</string>
+		<string>RobotoCondensed-Bold.ttf</string>
 	</array>
 	<key>VolumeThumbImage</key>
 	<string>VolumeThumb</string>


### PR DESCRIPTION
[PLAYER-4099] [iOS] Save analytics data when device is offline
Shows the log of the files saved in the device for Analytics offline.
QA reported: "On iPADs, The analytics window is overlapped on player". This PR solves this issue.