### PR TITLE
[PLAYER-4327] Fixed crashing with DTO sample app

### DIFF
--- a/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Managers/AssetPersistenceManager.m
+++ b/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Managers/AssetPersistenceManager.m
@@ -144,7 +144,7 @@ NSString * const AssetProgressKey = @"percentage";
   // find a download in progress for the given embed code, pause the download.
   NSLog(@"[AssetPersistenceManager] Attempting to pause a download for embed code: %@", embedCode);
   
-  NSMutableSet *downloadsPendingAuthCopy = self.downloadsPendingAuth.copy;
+  NSSet *downloadsPendingAuthCopy = self.downloadsPendingAuth.copy;
   
   for (OOAssetDownloadManager *downloadManager in downloadsPendingAuthCopy) {
     if ([downloadManager.embedCode isEqualToString:embedCode]) {
@@ -161,7 +161,7 @@ NSString * const AssetProgressKey = @"percentage";
     }
   }
   
-  NSMutableSet *activeDownloadsCopy = self.activeDownloads.copy;
+  NSSet *activeDownloadsCopy = self.activeDownloads.copy;
   
   for (OOAssetDownloadManager *downloadManager in activeDownloadsCopy) {
     if ([downloadManager.embedCode isEqualToString:embedCode]) {
@@ -184,7 +184,7 @@ NSString * const AssetProgressKey = @"percentage";
   // find a paused download for the given embed code, resume the download.
   NSLog(@"[AssetPersistenceManager] Attempting to resume a download for embed code: %@", embedCode);
   
-  NSMutableSet *pausedDownloadsCopy = self.pausedDownloads.copy;
+  NSSet *pausedDownloadsCopy = self.pausedDownloads.copy;
   
   for (OOAssetDownloadManager *downloadManager in pausedDownloadsCopy) {
     if ([downloadManager.embedCode isEqualToString:embedCode]) {
@@ -207,7 +207,7 @@ NSString * const AssetProgressKey = @"percentage";
   // find a download in progress for the given embed code, cancel the download and remove the remaining contents if something was downloaded already.
   NSLog(@"[AssetPersistenceManager] Attempting to cancel a download for embed code: %@", embedCode);
   
-  NSMutableSet *downloadsPendingAuthCopy = self.downloadsPendingAuth.copy;
+  NSSet *downloadsPendingAuthCopy = self.downloadsPendingAuth.copy;
   
   for (OOAssetDownloadManager *downloadManager in downloadsPendingAuthCopy) {
     if ([downloadManager.embedCode isEqualToString:embedCode]) {
@@ -217,7 +217,7 @@ NSString * const AssetProgressKey = @"percentage";
     }
   }
   
-  NSMutableSet *activeDownloadsCopy = self.activeDownloads.copy;
+  NSSet *activeDownloadsCopy = self.activeDownloads.copy;
   
   for (OOAssetDownloadManager *downloadManager in activeDownloadsCopy) {
     if ([downloadManager.embedCode isEqualToString:embedCode]) {

--- a/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Managers/AssetPersistenceManager.m
+++ b/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Managers/AssetPersistenceManager.m
@@ -144,7 +144,9 @@ NSString * const AssetProgressKey = @"percentage";
   // find a download in progress for the given embed code, pause the download.
   NSLog(@"[AssetPersistenceManager] Attempting to pause a download for embed code: %@", embedCode);
   
-  for (OOAssetDownloadManager *downloadManager in self.downloadsPendingAuth) {
+  NSMutableSet *downloadsPendingAuthCopy = self.downloadsPendingAuth.copy;
+  
+  for (OOAssetDownloadManager *downloadManager in downloadsPendingAuthCopy) {
     if ([downloadManager.embedCode isEqualToString:embedCode]) {
       [downloadManager pauseDownload];
       [self.downloadsPendingAuth removeObject:downloadManager];
@@ -159,9 +161,12 @@ NSString * const AssetProgressKey = @"percentage";
     }
   }
   
-  for (OOAssetDownloadManager *downloadManager in self.activeDownloads) {
+  NSMutableSet *activeDownloadsCopy = self.activeDownloads.copy;
+  
+  for (OOAssetDownloadManager *downloadManager in activeDownloadsCopy) {
     if ([downloadManager.embedCode isEqualToString:embedCode]) {
       [downloadManager pauseDownload];
+      
       [self.activeDownloads removeObject:downloadManager];
       [self.pausedDownloads addObject:downloadManager];
       
@@ -178,9 +183,13 @@ NSString * const AssetProgressKey = @"percentage";
 - (void)resumeDownloadForEmbedCode:(NSString *)embedCode {
   // find a paused download for the given embed code, resume the download.
   NSLog(@"[AssetPersistenceManager] Attempting to resume a download for embed code: %@", embedCode);
-  for (OOAssetDownloadManager *downloadManager in self.pausedDownloads) {
+  
+  NSMutableSet *pausedDownloadsCopy = self.pausedDownloads.copy;
+  
+  for (OOAssetDownloadManager *downloadManager in pausedDownloadsCopy) {
     if ([downloadManager.embedCode isEqualToString:embedCode]) {
       [downloadManager resumeDownload];
+      
       [self.pausedDownloads removeObject:downloadManager];
       [self.activeDownloads addObject:downloadManager];
       
@@ -197,7 +206,10 @@ NSString * const AssetProgressKey = @"percentage";
 - (void)cancelDownloadForEmbedCode:(NSString *)embedCode {
   // find a download in progress for the given embed code, cancel the download and remove the remaining contents if something was downloaded already.
   NSLog(@"[AssetPersistenceManager] Attempting to cancel a download for embed code: %@", embedCode);
-  for (OOAssetDownloadManager *downloadManager in self.downloadsPendingAuth) {
+  
+  NSMutableSet *downloadsPendingAuthCopy = self.downloadsPendingAuth.copy;
+  
+  for (OOAssetDownloadManager *downloadManager in downloadsPendingAuthCopy) {
     if ([downloadManager.embedCode isEqualToString:embedCode]) {
       [downloadManager cancelDownload];
       [self.downloadsPendingAuth removeObject:downloadManager];
@@ -205,7 +217,9 @@ NSString * const AssetProgressKey = @"percentage";
     }
   }
   
-  for (OOAssetDownloadManager *downloadManager in self.activeDownloads) {
+  NSMutableSet *activeDownloadsCopy = self.activeDownloads.copy;
+  
+  for (OOAssetDownloadManager *downloadManager in activeDownloadsCopy) {
     if ([downloadManager.embedCode isEqualToString:embedCode]) {
       [downloadManager cancelDownload];
       [self.activeDownloads removeObject:downloadManager];


### PR DESCRIPTION
- fixed crashing with DTO sample app

The problem was in the unsupported work with `NSMutableSet` into forEach loop. 

Unit tests not included.
Ticket: https://jira.corp.ooyala.com/browse/PLAYER-4327