### PR TITLE
[PLAYER-4565] - Create Swift Sample App for TVOS

### DIFF
--- a/PlaybackLab/TVOSSwiftSampleApp/TVOSSwiftSampleApp.xcodeproj/project.pbxproj
+++ b/PlaybackLab/TVOSSwiftSampleApp/TVOSSwiftSampleApp.xcodeproj/project.pbxproj
@@ -541,6 +541,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.ooyala.TVOSSwiftSampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/TVOSSwiftSampleApp/TVOSSwiftSampleApp-Bridging-Header.h";
@@ -573,6 +574,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.ooyala.TVOSSwiftSampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/TVOSSwiftSampleApp/TVOSSwiftSampleApp-Bridging-Header.h";


### PR DESCRIPTION
Adding missing "-ObjC" linker flag to TVOSSwiftSampleApp, this flag prevents some crashes regarding inaccessible core code from Swift side. 