### PR TITLE
[PLAYER-4663][IMA Sample App][Ooyala Skin SampleApp][pulse Sample App] Build Failure

### DIFF
--- a/PulseSampleApp/PulseSampleApp.xcodeproj/project.pbxproj
+++ b/PulseSampleApp/PulseSampleApp.xcodeproj/project.pbxproj
@@ -564,6 +564,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = 556Y9XWD3N;
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -599,6 +600,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = 556Y9XWD3N;
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = (


### PR DESCRIPTION
The problem was about multiple including PlayerProtocol file from different frameworks. The similar problem was fixed in https://jira.corp.ooyala.com:8443/browse/PLAYER-4355. One part of the workaround is to use module importing instead of headers importing. In current candidate branch I cannot see module roadmap in ooyalasdk framework, so it tells us about old or broken framework. I also have tested actual framework build from dev/candidate/stable branches to be ensured the problem is in bad framework build and everything is Ok. Additional fix required: is to add appropriate ooyala-sdk framework


