### PR TITLE
[PBA-6667] ControlsLockScreenSampleApp's

### DIFF
--- a/PlaybackLab/ControlsLockScreenSampleApp/ControlsLockScreenSampleApp.xcodeproj/project.pbxproj
+++ b/PlaybackLab/ControlsLockScreenSampleApp/ControlsLockScreenSampleApp.xcodeproj/project.pbxproj
@@ -420,6 +420,7 @@
 				INFOPLIST_FILE = "ControlsLockScreenSampleApp/Support Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.ooyala.ControlsLockScreenSampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "ControlsLockScreenSampleApp/Support Files/ControlsLockScreenSampleApp-Bridging-Header.h";
@@ -436,6 +437,7 @@
 				INFOPLIST_FILE = "ControlsLockScreenSampleApp/Support Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.ooyala.ControlsLockScreenSampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "ControlsLockScreenSampleApp/Support Files/ControlsLockScreenSampleApp-Bridging-Header.h";


### PR DESCRIPTION
ControlsLockScreenSampleApp's crashes when user taps on any video asset on defaults screen. Crash caused unrecognized selector exception in iOS-SDK `-[OOOoyalaPlayer registerAdPlayer:forType:]`. Fixed by adding `-objc` linker flag into project's build settings to enable using Objective-C methods.
Unit test wasn't added (there is no Unit test target in project).