### PR TITLE
[Player 5287] Instead of language its showing Words after click on “CC” button.

### DIFF
--- a/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/LocalizationLanguagesViewController.m
+++ b/AdvancedPlaybackSampleApp/AdvancedPlaybackSampleApp/Players/LocalizationLanguagesViewController.m
@@ -97,7 +97,7 @@
   
   NSMutableDictionary *english = [mutableLanguages[@"en"] mutableCopy];
   english[@"Done"] = @"Done";
-  english[@"Languages"] = @"Words";
+  english[@"Languages"] = @"Languages";
   english[@"Subtitles"] = @"Closed captions";
   mutableLanguages[@"en"] = english;
   


### PR DESCRIPTION
 Instead of language its showing Words after click on “CC” button.
Changed value for dictionary key, which contains wrong localization.
Tests were not added, because there is no test target.