### PR TITLE
[PLAYER-5543] Player Fails to Load the asset while scrolling back and forth

### DIFF
--- a/PlaybackLab/MultiplePlayersScrollingViewSampleApp/MultiplePlayersScrollingViewSampleApp/ViewControllers/MultiplePlayerViewController.swift
+++ b/PlaybackLab/MultiplePlayersScrollingViewSampleApp/MultiplePlayersScrollingViewSampleApp/ViewControllers/MultiplePlayerViewController.swift
@@ -162,9 +162,6 @@ class MultiplePlayerViewController: UIViewController {
         return
       }
       
-      self.sharedPlayer.player.setEmbedCode(playerSelectionOption.embedCode)
-      self.sharedPlayer.player.play(withInitialTime: playerSelectionOption.playheadTime)
-      
       cell.videoView.addSubview(self.sharedPlayer.view)
       NSLayoutConstraint.activate([
         self.sharedPlayer.view.topAnchor.constraint(equalTo: cell.videoView.topAnchor),
@@ -172,6 +169,11 @@ class MultiplePlayerViewController: UIViewController {
         self.sharedPlayer.view.trailingAnchor.constraint(equalTo: cell.videoView.trailingAnchor),
         self.sharedPlayer.view.leadingAnchor.constraint(equalTo: cell.videoView.leadingAnchor),
         ])
+      
+      if Thread.isMainThread {
+        self.sharedPlayer.player.setEmbedCode(playerSelectionOption.embedCode)
+        self.sharedPlayer.player.play(withInitialTime: playerSelectionOption.playheadTime)
+      }
     }
     
   }


### PR DESCRIPTION
Setting the embedCode is throwing an error for multiple request.
Only mainThread is requesting the authorization, metadata, contentTree, etc.

Tested on 
iPhone X, iOS 12.2
iPhone 8, iOS 11.4.1