### PR TITLE
[PLAYER-5005] Enabling background downloading for DTO sample apps

### DIFF
--- a/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/AppDelegate.m
+++ b/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/AppDelegate.m
@@ -7,48 +7,43 @@
 //
 
 #import "AppDelegate.h"
-
-@interface AppDelegate ()
-
-@end
+#import <OoyalaSDK/OODtoAsset.h>
+#import "OptionsDataSource.h"
 
 @implementation AppDelegate
 
-
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   // Override point for customization after application launch.
+  [OODtoAsset restoreAllDownloadsForDtoAssets:OptionsDataSource.dtoAssets];
   return YES;
 }
-
 
 - (void)applicationWillResignActive:(UIApplication *)application {
   // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
   // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
 }
 
-
 - (void)applicationDidEnterBackground:(UIApplication *)application {
   // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
   // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
 }
 
-
 - (void)applicationWillEnterForeground:(UIApplication *)application {
   // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
 }
-
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
   // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
 }
 
-
 - (void)applicationWillTerminate:(UIApplication *)application {
   // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 }
 
-- (void)application:(UIApplication *)application handleEventsForBackgroundURLSession:(NSString *)identifier completionHandler:(void (^)(void))completionHandler {
-  
+- (void)application:(UIApplication *)application
+handleEventsForBackgroundURLSession:(NSString *)identifier
+  completionHandler:(void (^)(void))completionHandler {
+  [OODtoAsset setBackgroundSessionCompletionHandler:completionHandler];
 }
 
 @end

--- a/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Lists/AssetListViewController.m
+++ b/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Lists/AssetListViewController.m
@@ -15,7 +15,7 @@
 
 @interface AssetListViewController ()
 
-@property (nonatomic) NSMutableArray<OODtoAsset *> *dtoAssets;
+@property (nonatomic) NSArray<OODtoAsset *> *dtoAssets;
 @property NSIndexPath *selectedIndexPath;
 
 @end
@@ -35,11 +35,7 @@ static NSString *const playerSegue = @"videoSegue";
   self.tableView.tableFooterView = [UIView new];
 
   // Create data for table view
-  self.dtoAssets = [NSMutableArray array];
-  NSArray *options = OptionsDataSource.options;
-  for (PlayerSelectionOption *oneOption in options) {
-    [self.dtoAssets addObject:[self buildDtoAssetForOption:oneOption]];
-  }
+  self.dtoAssets = OptionsDataSource.dtoAssets;
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -50,21 +46,6 @@ static NSString *const playerSegue = @"videoSegue";
 }
 
 #pragma mark - Private functions
-
-/**
- Builds an OODtoAsset with the given options.
-
- @param option PlayerSelectionOption with the asset information.
- @return new OODtoAsset instance.
- */
-- (OODtoAsset *)buildDtoAssetForOption:(PlayerSelectionOption *)option {
-  OOAssetDownloadOptions *options = [OOAssetDownloadOptions new];
-  options.pcode = option.pcode;
-  options.embedCode = option.embedCode;
-  options.domain = [OOPlayerDomain domainWithString:option.domain];
-  options.embedTokenGenerator = option.embedTokenGenerator;
-  return [[OODtoAsset alloc] initWithOptions:options andName:option.title];
-}
 
 /**
  Re-sets closures for the selected cell after coming back from PlayerViewController

--- a/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Players/PlayerViewController.m
+++ b/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Players/PlayerViewController.m
@@ -17,7 +17,7 @@ typedef NS_ENUM(NSInteger, DownloadMode) {
   Undefined
 };
 
-@interface PlayerViewController ()
+@interface PlayerViewController () <OOEmbedTokenGenerator>
 
 @property (weak, nonatomic) IBOutlet UIView *playerView;
 
@@ -145,6 +145,12 @@ typedef NS_ENUM(NSInteger, DownloadMode) {
   [self.ooyalaPlayerViewController.player pause];
   [self.ooyalaPlayerViewController.player setPlayheadTime:0];
   [self.ooyalaPlayerViewController.player play];
+}
+
+- (void)tokenForEmbedCodes:(NSArray<NSString *> *)embedCodes
+                  callback:(OOEmbedTokenCallback)callback {
+  [self.dtoAsset.options.embedTokenGenerator tokenForEmbedCodes:embedCodes
+                                                       callback:callback];
 }
 
 @end

--- a/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Utils/OptionsDataSource.h
+++ b/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Utils/OptionsDataSource.h
@@ -8,6 +8,8 @@
 
 @import Foundation;
 
+@class OODtoAsset;
+
 /**
  Manages the assets to be downloaded.
  */
@@ -16,5 +18,7 @@
  @return an Array of PlayerSelectionOption instances to be used throughout the app. 
  */
 + (NSArray *)options;
+
++ (NSMutableArray<OODtoAsset *> *)dtoAssets;
 
 @end

--- a/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Utils/OptionsDataSource.m
+++ b/PlaybackLab/DownloadToOwnSampleApp/DownloadToOwnSampleApp/Utils/OptionsDataSource.m
@@ -9,6 +9,7 @@
 #import "OptionsDataSource.h"
 #import "PlayerSelectionOption.h"
 #import "BasicEmbedTokenGenerator.h"
+#import <OoyalaSDK/OoyalaSDK.h>
 
 @implementation OptionsDataSource
 
@@ -46,6 +47,29 @@
            
            // if required, add more test cases here
            ];
+}
+
++ (NSMutableArray<OODtoAsset *> *)dtoAssets {
+  NSMutableArray *options = [NSMutableArray array];
+  for (PlayerSelectionOption *oneOption in self.options) {
+    [options addObject:[self buildDtoAssetForOption:oneOption]];
+  }
+  return options;
+}
+
+/**
+ Builds an OODtoAsset with the given options.
+
+ @param option PlayerSelectionOption with the asset information.
+ @return new OODtoAsset instance.
+ */
++ (OODtoAsset *)buildDtoAssetForOption:(PlayerSelectionOption *)option {
+  OOAssetDownloadOptions *options = [OOAssetDownloadOptions new];
+  options.pcode = option.pcode;
+  options.embedCode = option.embedCode;
+  options.domain = [OOPlayerDomain domainWithString:option.domain];
+  options.embedTokenGenerator = option.embedTokenGenerator;
+  return [OODtoAsset initWithOptions:options andName:option.title];
 }
 
 @end

--- a/PlaybackLab/DownloadToOwnSampleAppSwift/DownloadToOwnSampleAppSwift/Supporting Files/AppDelegate.swift
+++ b/PlaybackLab/DownloadToOwnSampleAppSwift/DownloadToOwnSampleAppSwift/Supporting Files/AppDelegate.swift
@@ -17,7 +17,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication,
                    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // Override point for customization after application launch.
+    OODtoAsset.restoreAllDownloads(for: OptionDataSource.dtoAssets as! NSMutableArray)
     return true
+  }
+
+  func application(_ application: UIApplication,
+                   handleEventsForBackgroundURLSession identifier: String,
+                   completionHandler: @escaping () -> Void) {
+    OODtoAsset.setBackgroundSessionCompletionHandler(completionHandler)
   }
   
   func application(_ application: UIApplication,

--- a/PlaybackLab/DownloadToOwnSampleAppSwift/DownloadToOwnSampleAppSwift/Views/PlayerViewController.swift
+++ b/PlaybackLab/DownloadToOwnSampleAppSwift/DownloadToOwnSampleAppSwift/Views/PlayerViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class PlayerViewController: UIViewController {
+class PlayerViewController: UIViewController, OOEmbedTokenGenerator {
   
   @IBOutlet weak var titleLabel: UILabel!
   
@@ -118,5 +118,9 @@ class PlayerViewController: UIViewController {
   deinit {
     print("<PlayerViewController> has been destroyed.")
   }
-  
+
+  func token(forEmbedCodes embedCodes: [String], callback: @escaping OOEmbedTokenCallback) {
+    guard let embedTokenGenerator = dtoAsset.options.embedTokenGenerator else { return }
+    embedTokenGenerator.token(forEmbedCodes: embedCodes, callback: callback)
+  }
 }


### PR DESCRIPTION
In order to have fully working background downloading for DTO assets one should do:

- in `didFinishLaunchingWithOptions` pass an array of `OODtoAsset` like this:
 ```[OODtoAsset restoreAllDownloadsForDtoAssets:OptionsDataSource.dtoAssets];```
- in  `handleEventsForBackgroundURLSession` pass a completion handler provided by the system: 
```[OODtoAsset setBackgroundSessionCompletionHandler:completionHandler];```