### PR TITLE
[PLAYER-5638] Ad are playing on background after click on “learn more” button

### DIFF
--- a/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
@@ -68,7 +68,7 @@
 
   OOOptions *options = [OOOptions new];
   options.enablePictureInPictureSupport = YES;
-  options.backgroundMode = OOBackgroundPlaybackModeAllowed; // OOBackgroundPlaybackModeAllowed
+  options.backgroundMode = OOBackgroundPlaybackModeDisabled;
   if (self.isAudioOnlyAsset) {
     options.playerInfo = [OODefaultAudioOnlyPlayerInfo new];
   } else {


### PR DESCRIPTION
OOBackgroundPlaybackMode must be disabled by default.
For ios app on some level switching to Safari for playing ad it is the same as going into background. That's why in case when OOBackgroundPlaybackMode is allowed app comprehends playing ad as casual playback and allows player to play sound.

I suggest to move defining and implementing usecases for OOBackgroundPlaybackMode is allowed in separate topic as new subticket of [this story](https://jira.corp.ooyala.com/browse/PLAYER-5463)