### PR TITLE
[PLAYER-5456] Delay of response for button 'start playing'

### DIFF
--- a/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
@@ -105,7 +105,7 @@
   __weak typeof(self) weakSelf = self;
   [self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode withCallback:^(OOOoyalaError *error) {
    
-    LOG(@"✅ got callback. embed: %@, is success: %d", weakSelf.ooyalaPlayerViewController.player.currentItem.embedCode, (error == nil));
+    LOG(@"✅ got callback. embed: %@, is success: %@", weakSelf.ooyalaPlayerViewController.player.currentItem.embedCode, (error == nil) ? @"YES" : @"NO");
     if (weakSelf && !error) {
       [weakSelf.ooyalaPlayerViewController.player play];
     } else {

--- a/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
@@ -9,6 +9,7 @@
 #import "BasicSimplePlayerViewController.h"
 #import <OoyalaSDK/OoyalaSDK.h>
 #import <OoyalaSDK/OOOptions.h>
+#import <OoyalaSDK/OODebugMode.h>
 
 #import "AppDelegate.h"
 
@@ -101,14 +102,14 @@
   //[self.ooyalaPlayerViewController.player play];
   
   //new API. Uncomment when SDK version become more then 4.46.0_GA
-  __weak BasicSimplePlayerViewController *weakSelf = self;
+  __weak typeof(self) weakSelf = self;
   [self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode withCallback:^(OOOoyalaError *error) {
    
-    NSLog(@"✅ got callback. embed: %@, is success: %d", weakSelf.ooyalaPlayerViewController.player.currentItem.embedCode, (error == nil));
+    LOG(@"✅ got callback. embed: %@, is success: %d", weakSelf.ooyalaPlayerViewController.player.currentItem.embedCode, (error == nil));
     if (weakSelf && !error) {
       [weakSelf.ooyalaPlayerViewController.player play];
     } else {
-      NSLog(@"❌ error: %@", error.debugDescription);
+      LOG(@"❌ error: %@", error.debugDescription);
     }
   }];
 }

--- a/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
@@ -102,10 +102,9 @@
   //[self.ooyalaPlayerViewController.player play];
   
   //new API. Uncomment when SDK version become more then 4.46.0_GA
-  [self.ooyalaPlayerViewController.player activateDelayedPlaybackWhenReadyForEmbedCode:self.embedCode];
   
   __weak typeof(self) weakSelf = self;
-  [self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode withCallback:^(OOOoyalaError *error) {
+  [self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode shouldAutoPlay:YES withCallback:^(OOOoyalaError *error) {
     //just for debug purpose and demonstration that caalback can be usefull, remove if you don't need
     LOG(@"✅ got callback. embed: %@, is success: %@. But it doesn't mean that status is 'AVPlayerItemStatusReadyToPlay'", weakSelf.ooyalaPlayerViewController.player.currentItem.embedCode, (error == nil) ? @"YES" : @"NO");
   }];

--- a/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
@@ -102,12 +102,10 @@
   expectedBlock = ^(OOVideo *currentItem) {
     LOG(@"✅ got expectedBlock");
     if ([currentItem.embedCode isEqualToString:weakSelf.embedCode]) {
-      NSLog(@"✅ aseet with embed code %@", currentItem.embedCode);
+      LOG(@"✅ aseet with embed code %@", currentItem.embedCode);
       [weakSelf.ooyalaPlayerViewController.player play];
       //OS: block must be removed after '[weakSelf.player play]', to prevent ignition from OOBaseStreamPlayer's KVO 'AVPlayerItemStatusReadyToPlay'
       weakSelf.ooyalaPlayerViewController.player.currentItemChangedCallback = nil;
-    } else {
-      NSLog(@"❌ Error: got player with embed code [%@] that is not expected", currentItem.embedCode);
     }
   };
   self.ooyalaPlayerViewController.player.currentItemChangedCallback = expectedBlock; //OOCurrentItemChangedCallback
@@ -120,9 +118,6 @@
   //new API. Uncomment when SDK version become more then 4.46.0_GA
   [self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode withCallback:^(OOOoyalaError *error) {
     LOG(@"✅ got callback. embed: %@, is success: %@. But it doesn't mean that status is 'AVPlayerItemStatusReadyToPlay'", weakSelf.ooyalaPlayerViewController.player.currentItem.embedCode, (error == nil) ? @"YES" : @"NO");
-    if (error) {
-      LOG(@"❌ error: %@", error.debugDescription);
-    }
   }];
 }
 

--- a/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
@@ -104,28 +104,27 @@
   //new API. Uncomment when SDK version become more then 4.46.0_GA
   __weak typeof(self) weakSelf = self;
   
-  //OS: to avoid calling '[weakSelf.player play]' until player really ready to play
-  void (^expectedBlock) (OOVideo *currentItem);
-  expectedBlock = ^ (OOVideo *currentItem) {
-    LOG(@"✅ ✅ ✅ got expectedBlock");
-    if ([currentItem.embedCode isEqualToString:weakSelf.embedCode]) {
-      NSLog(@"✅ aseet with embed code %@", currentItem.embedCode);
-      [weakSelf.ooyalaPlayerViewController.player play];
-      //OS: block must be removed after '[weakSelf.player play]', to prevent ignition from OOBaseStreamPlayer's KVO 'AVPlayerItemStatusReadyToPlay'
-      weakSelf.ooyalaPlayerViewController.player.currentItemChangedCallback = nil;
-    } else {
-      NSLog(@"❌ aseet with embed code %@ must be in hospital and take injections", currentItem.embedCode);
-    }
-  };
-  self.ooyalaPlayerViewController.player.currentItemChangedCallback = expectedBlock; //OOCurrentItemChangedCallback
-
-  
   [self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode withCallback:^(OOOoyalaError *error) {
     LOG(@"✅ got callback. embed: %@, is success: %@. But it doesn't mean that status is 'AVPlayerItemStatusReadyToPlay'", weakSelf.ooyalaPlayerViewController.player.currentItem.embedCode, (error == nil) ? @"YES" : @"NO");
     if (error) {
       LOG(@"❌ error: %@", error.debugDescription);
     }
   }];
+  
+  //OS: to avoid calling '[weakSelf.player play]' until player really ready to play
+  void (^expectedBlock) (OOVideo *currentItem);
+  expectedBlock = ^ (OOVideo *currentItem) {
+    LOG(@"✅ got expectedBlock");
+    if ([currentItem.embedCode isEqualToString:weakSelf.embedCode]) {
+      NSLog(@"✅ aseet with embed code %@", currentItem.embedCode);
+      [weakSelf.ooyalaPlayerViewController.player play];
+      //OS: block must be removed after '[weakSelf.player play]', to prevent ignition from OOBaseStreamPlayer's KVO 'AVPlayerItemStatusReadyToPlay'
+      weakSelf.ooyalaPlayerViewController.player.currentItemChangedCallback = nil;
+    } else {
+      NSLog(@"❌ asset with embed code %@ must be in hospital and take injections", currentItem.embedCode);
+    }
+  };
+  self.ooyalaPlayerViewController.player.currentItemChangedCallback = expectedBlock; //OOCurrentItemChangedCallback
 }
 
 #pragma mark - Private functions

--- a/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
@@ -113,7 +113,7 @@
   
   //OS: to avoid calling '[weakSelf.player play]' until player really ready to play
   void (^expectedBlock) (OOVideo *currentItem);
-  expectedBlock = ^ (OOVideo *currentItem) {
+  expectedBlock = ^(OOVideo *currentItem) {
     LOG(@"✅ got expectedBlock");
     if ([currentItem.embedCode isEqualToString:weakSelf.embedCode]) {
       NSLog(@"✅ aseet with embed code %@", currentItem.embedCode);
@@ -121,7 +121,7 @@
       //OS: block must be removed after '[weakSelf.player play]', to prevent ignition from OOBaseStreamPlayer's KVO 'AVPlayerItemStatusReadyToPlay'
       weakSelf.ooyalaPlayerViewController.player.currentItemChangedCallback = nil;
     } else {
-      NSLog(@"❌ asset with embed code %@ must be in hospital and take injections", currentItem.embedCode);
+      NSLog(@"❌ Error: got player with embed code [%@] that is not expected", currentItem.embedCode);
     }
   };
   self.ooyalaPlayerViewController.player.currentItemChangedCallback = expectedBlock; //OOCurrentItemChangedCallback

--- a/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
@@ -96,21 +96,7 @@
   // Attach it to current view
   [self addPlayerViewController:self.ooyalaPlayerViewController];
   
-  // Load the video
-  //[self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode];
-  //Deprecated API. Remove this call when SDK version become more then 4.46.0_GA. Uncomment code with Asynchronous method instead.
-  //[self.ooyalaPlayerViewController.player play];
-  
-  //new API. Uncomment when SDK version become more then 4.46.0_GA
   __weak typeof(self) weakSelf = self;
-  
-  [self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode withCallback:^(OOOoyalaError *error) {
-    LOG(@"✅ got callback. embed: %@, is success: %@. But it doesn't mean that status is 'AVPlayerItemStatusReadyToPlay'", weakSelf.ooyalaPlayerViewController.player.currentItem.embedCode, (error == nil) ? @"YES" : @"NO");
-    if (error) {
-      LOG(@"❌ error: %@", error.debugDescription);
-    }
-  }];
-  
   //OS: to avoid calling '[weakSelf.player play]' until player really ready to play
   void (^expectedBlock) (OOVideo *currentItem);
   expectedBlock = ^(OOVideo *currentItem) {
@@ -125,6 +111,19 @@
     }
   };
   self.ooyalaPlayerViewController.player.currentItemChangedCallback = expectedBlock; //OOCurrentItemChangedCallback
+  
+  // Load the video
+  //[self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode];
+  //Deprecated API. Remove this call when SDK version become more then 4.46.0_GA. Uncomment code with Asynchronous method instead.
+  //[self.ooyalaPlayerViewController.player play];
+  
+  //new API. Uncomment when SDK version become more then 4.46.0_GA
+  [self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode withCallback:^(OOOoyalaError *error) {
+    LOG(@"✅ got callback. embed: %@, is success: %@. But it doesn't mean that status is 'AVPlayerItemStatusReadyToPlay'", weakSelf.ooyalaPlayerViewController.player.currentItem.embedCode, (error == nil) ? @"YES" : @"NO");
+    if (error) {
+      LOG(@"❌ error: %@", error.debugDescription);
+    }
+  }];
 }
 
 #pragma mark - Private functions

--- a/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
@@ -99,17 +99,21 @@
   [self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode];
   //Deprecated API. Remove this call when SDK version become more then 4.46.0_GA. Uncomment code with Asynchronous method instead.
   [self.ooyalaPlayerViewController.player play];
+
   
   //new API. Uncomment when SDK version become more then 4.46.0_GA
   /*
   __weak BasicSimplePlayerViewController *weakSelf = self;
-  [self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode withCallback:^(BOOL isSuccess) {
-    NSLog(@"✅ got callback. is Success: %d", isSuccess);
-    if (weakSelf && isSuccess) {
+  [self.ooyalaPlayerViewController.player setEmbedCode:asset withCallback:^(OOOoyalaError *error) {
+   
+    NSLog(@"✅ got callback. is success: %d", (error == nil));
+    NSLog(@"----");
+    if (weakSelf && !error) {
       [weakSelf.ooyalaPlayerViewController.player play];
+    } else {
+      NSLog(@"❌ error: %@", error.debugDescription);
     }
-  }];
-*/
+  }];*/
 }
 
 #pragma mark - Private functions

--- a/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
@@ -96,27 +96,17 @@
   // Attach it to current view
   [self addPlayerViewController:self.ooyalaPlayerViewController];
   
-  __weak typeof(self) weakSelf = self;
-  //OS: to avoid calling '[weakSelf.player play]' until player really ready to play
-  void (^expectedBlock) (OOVideo *currentItem);
-  expectedBlock = ^(OOVideo *currentItem) {
-    LOG(@"✅ got expectedBlock");
-    if ([currentItem.embedCode isEqualToString:weakSelf.embedCode]) {
-      LOG(@"✅ aseet with embed code %@", currentItem.embedCode);
-      [weakSelf.ooyalaPlayerViewController.player play];
-      //OS: block must be removed after '[weakSelf.player play]', to prevent ignition from OOBaseStreamPlayer's KVO 'AVPlayerItemStatusReadyToPlay'
-      weakSelf.ooyalaPlayerViewController.player.currentItemChangedCallback = nil;
-    }
-  };
-  self.ooyalaPlayerViewController.player.currentItemChangedCallback = expectedBlock; //OOCurrentItemChangedCallback
-  
   // Load the video
+  //Deprecated API. Remove this calls when SDK version become more then 4.46.0_GA. Uncomment code with Asynchronous method instead.
   //[self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode];
-  //Deprecated API. Remove this call when SDK version become more then 4.46.0_GA. Uncomment code with Asynchronous method instead.
   //[self.ooyalaPlayerViewController.player play];
   
   //new API. Uncomment when SDK version become more then 4.46.0_GA
+  [self.ooyalaPlayerViewController.player activateDelayedPlaybackWhenReadyForEmbedCode:self.embedCode];
+  
+  __weak typeof(self) weakSelf = self;
   [self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode withCallback:^(OOOoyalaError *error) {
+    //just for debug purpose and demonstration that caalback can be usefull, remove if you don't need
     LOG(@"✅ got callback. embed: %@, is success: %@. But it doesn't mean that status is 'AVPlayerItemStatusReadyToPlay'", weakSelf.ooyalaPlayerViewController.player.currentItem.embedCode, (error == nil) ? @"YES" : @"NO");
   }];
 }

--- a/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
@@ -96,24 +96,21 @@
   [self addPlayerViewController:self.ooyalaPlayerViewController];
   
   // Load the video
-  [self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode];
+  //[self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode];
   //Deprecated API. Remove this call when SDK version become more then 4.46.0_GA. Uncomment code with Asynchronous method instead.
-  [self.ooyalaPlayerViewController.player play];
-
+  //[self.ooyalaPlayerViewController.player play];
   
   //new API. Uncomment when SDK version become more then 4.46.0_GA
-  /*
   __weak BasicSimplePlayerViewController *weakSelf = self;
-  [self.ooyalaPlayerViewController.player setEmbedCode:asset withCallback:^(OOOoyalaError *error) {
+  [self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode withCallback:^(OOOoyalaError *error) {
    
-    NSLog(@"✅ got callback. is success: %d", (error == nil));
-    NSLog(@"----");
+    NSLog(@"✅ got callback. embed: %@, is success: %d", weakSelf.ooyalaPlayerViewController.player.currentItem.embedCode, (error == nil));
     if (weakSelf && !error) {
       [weakSelf.ooyalaPlayerViewController.player play];
     } else {
       NSLog(@"❌ error: %@", error.debugDescription);
     }
-  }];*/
+  }];
 }
 
 #pragma mark - Private functions

--- a/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
@@ -159,4 +159,8 @@
 }
 
 
+- (void)callbackListener {
+  
+}
+
 @end

--- a/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/BasicPlaybackSampleApp/BasicPlaybackSampleApp/Players/BasicSimplePlayerViewController.m
@@ -97,7 +97,19 @@
   
   // Load the video
   [self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode];
-  [self.ooyalaPlayerViewController.player play];  
+  //Deprecated API. Remove this call when SDK version become more then 4.46.0_GA. Uncomment code with Asynchronous method instead.
+  [self.ooyalaPlayerViewController.player play];
+  
+  //new API. Uncomment when SDK version become more then 4.46.0_GA
+  /*
+  __weak BasicSimplePlayerViewController *weakSelf = self;
+  [self.ooyalaPlayerViewController.player setEmbedCode:self.embedCode withCallback:^(BOOL isSuccess) {
+    NSLog(@"✅ got callback. is Success: %d", isSuccess);
+    if (weakSelf && isSuccess) {
+      [weakSelf.ooyalaPlayerViewController.player play];
+    }
+  }];
+*/
 }
 
 #pragma mark - Private functions

--- a/PlaybackLab/PictureInPictureSampleApp/PictureInPictureSampleApp/Players/BasicSimplePlayerViewController.m
+++ b/PlaybackLab/PictureInPictureSampleApp/PictureInPictureSampleApp/Players/BasicSimplePlayerViewController.m
@@ -66,6 +66,7 @@
 
   OOOptions *options = [OOOptions new];
   options.enablePictureInPictureSupport = YES;
+  options.backgroundMode = OOBackgroundPlaybackModeDisabled;
   if (self.isAudioOnlyAsset) {
     options.playerInfo = [OODefaultAudioOnlyPlayerInfo new];
   } else {

--- a/PlaybackLab/PictureInPictureSampleApp/PictureInPictureSampleApp/Players/DefaultSkinPlayerViewController+AVPipControllerDelegate.m
+++ b/PlaybackLab/PictureInPictureSampleApp/PictureInPictureSampleApp/Players/DefaultSkinPlayerViewController+AVPipControllerDelegate.m
@@ -21,4 +21,13 @@
   [self updatePipButtonForStateIsActivated:false];
 }
 
+#pragma mark - Private methods
+// TODO: OS: it's better to change icon on pip-button (via notifying JS about appropriate event) from this place that is triggered by AVPipControllerDelegate.
+// But problem is to get access from this VC to *ooReactSkinModel 'OOReactSkinModel (is private property *skinModel in OOSkinViewController, it has APi for interacting with *skinEventsEmitter 'OOReactSkinEventsEmitter' and with *bridge 'RCTBridge' (OOReactSkinBridge))' (path 1) or create new notification in OOyalaSDK, post in here in 'DefaultSkinPlayerViewController (AVPipControllerDelegate)' and listen it in the 'OOSkinPlayerObserver' (path 2, what is too sophisticated solution as for me)
+
+- (void)updatePipButtonForStateIsActivated:(BOOL)isActivated {
+  //id params = @{isPipActivatedKey:@(isActivated), isPipButtonVisibleKey:@(true)};
+  //[self.skinController.player.bridge.skinEventsEmitter sendDeviceEventWithName:pipEventKey body:params];
+}
+
 @end

--- a/PlaybackLab/PictureInPictureSampleApp/PictureInPictureSampleApp/Players/DefaultSkinPlayerViewController.m
+++ b/PlaybackLab/PictureInPictureSampleApp/PictureInPictureSampleApp/Players/DefaultSkinPlayerViewController.m
@@ -58,6 +58,7 @@
   
   OOOptions *options = [OOOptions new];
   options.enablePictureInPictureSupport = YES;
+  
   BOOL canUsePip = options.enablePictureInPictureSupport &&
                    AVPictureInPictureController.isPictureInPictureSupported &&
                    !self.isAudioOnlyAsset;
@@ -96,15 +97,6 @@
   
   //Start playback
   [ooyalaPlayer setEmbedCode:self.embedCode];
-}
-
-#pragma mark - Private methods
-// TODO: OS: it's better to change icon on pip-button (via notifying JS about apropriate event) from this place that is triggered by AVPipControllerDelegate.
-// But problem is to get access from this VC to *ooReactSkinModel 'OOReactSkinModel (is private property *skinModel in OOSkinViewController, it has APi for interacting with *skinEventsEmitter 'OOReactSkinEventsEmitter' and with *bridge 'RCTBridge' (OOReactSkinBridge))' (path 1) or create new notification in OOyalaSDK, post in here in 'DefaultSkinPlayerViewController (AVPipControllerDelegate)' and listen it in the 'OOSkinPlayerObserver' (path 2, what is too sophisticated solution as for me)
-
-- (void)updatePipButtonForStateIsActivated:(BOOL)isActivated {
-  //id params = @{isPipActivatedKey:@(isActivated), isPipButtonVisibleKey:@(true)};
-  //[self.skinController.player.bridge.skinEventsEmitter sendDeviceEventWithName:pipEventKey body:params];
 }
 
 @end


### PR DESCRIPTION
Changes for using callback with block in COre-SDK that is triggered when OOOyalaPlayer is fully ready start playback. Only after this event we can ask for launching playback.
Also changes for using new methods in COre-SDK that return callback when embed code is set. 
**Affected repo-s:** Native-Skin + iOS-SDK + SampleApps