### PR TITLE
[PLAYER-5105] TVOSSwiftSampleApp. Video played duration is showing incorrectly if we seek till end.

### DIFF
--- a/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/ChildPlayerViewController.m
+++ b/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/ChildPlayerViewController.m
@@ -46,8 +46,7 @@
   [self.ooyalaPlayerViewController didMoveToParentViewController:self];
   
   // Load the video
-  [self.ooyalaPlayerViewController.player setEmbedCode:self.option.embedCode];
-  [self.ooyalaPlayerViewController.player play];
+  [self.ooyalaPlayerViewController.player setEmbedCode:self.option.embedCode shouldAutoPlay:YES withCallback:nil];
 }
 
 @end

--- a/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/FairplayPlayerViewController.m
+++ b/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/FairplayPlayerViewController.m
@@ -60,8 +60,7 @@
                                   embedTokenGenerator:self
                                               options:options];
   
-  [self.player setEmbedCode:self.option.embedCode];
-  [self.player play];
+  [self.player setEmbedCode:self.option.embedCode shouldAutoPlay:YES withCallback:nil];
 }
 
 - (void)tokenForEmbedCodes:(NSArray<NSString *> *)embedCodes

--- a/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/FullscreenPlayerViewController.m
+++ b/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/FullscreenPlayerViewController.m
@@ -33,8 +33,7 @@
                                              name:nil
                                            object:self.player];
   
-  [self.player setEmbedCode:self.option.embedCode];
-  [self.player play];
+  [self.player setEmbedCode:self.option.embedCode shouldAutoPlay:YES withCallback:nil];
 }
 
 - (void)notificationHandler:(NSNotification *)notification {

--- a/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/OoyalaPlayerTokenPlayerViewController.m
+++ b/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/OoyalaPlayerTokenPlayerViewController.m
@@ -48,8 +48,7 @@
                                                           domain:[[OOPlayerDomain alloc] initWithString:self.playerDomain]
                                              embedTokenGenerator:self];
   
-  [self.player setEmbedCode:self.option.embedCode];
-  [self.player play];
+  [self.player setEmbedCode:self.option.embedCode shouldAutoPlay:YES withCallback:nil];
 }
 
 - (void)tokenForEmbedCodes:(NSArray<NSString *> *)embedCodes

--- a/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/PulsePlayerViewController.m
+++ b/PlaybackLab/TVOSSampleApp/TVOSSampleApp/Players/PulsePlayerViewController.m
@@ -40,8 +40,7 @@ NSString *const PLAYER_DOMAIN = @"http://www.ooyala.com";
   self.manager = [[OOPulseManager alloc] initWithPlayer:self.player];
   self.manager.delegate = self;
   
-  [self.player setEmbedCode:self.option.embedCode];
-  [self.player play];
+  [self.player setEmbedCode:self.option.embedCode shouldAutoPlay:YES withCallback:nil];
 }
 
 - (void)notificationHandler:(NSNotification *)notification {

--- a/PlaybackLab/TVOSSwiftSampleApp/TVOSSwiftSampleApp/Players/ChildPlayerViewController.swift
+++ b/PlaybackLab/TVOSSwiftSampleApp/TVOSSwiftSampleApp/Players/ChildPlayerViewController.swift
@@ -39,8 +39,7 @@ class ChildPlayerViewController: AbstractPlayerViewController {
     ooyalaPlayerViewController.didMove(toParent: self)
     
     // Load the video
-    ooyalaPlayerViewController.player.setEmbedCode(option.embedCode)
-    ooyalaPlayerViewController.player.play()
+    ooyalaPlayerViewController.player.setEmbedCode(option.embedCode, shouldAutoPlay: true, withCallback: nil)
   }
   
 }

--- a/PlaybackLab/TVOSSwiftSampleApp/TVOSSwiftSampleApp/Players/FairplayPlayerViewController.swift
+++ b/PlaybackLab/TVOSSwiftSampleApp/TVOSSwiftSampleApp/Players/FairplayPlayerViewController.swift
@@ -39,8 +39,7 @@ class FairplayPlayerViewController: OOOoyalaTVPlayerViewController, OOEmbedToken
                                            name: nil,
                                            object: player)
     
-    player.setEmbedCode(option.embedCode)
-    player.play()
+    player.setEmbedCode(option.embedCode, shouldAutoPlay: true, withCallback: nil)
   }
   
   @objc func notificationHandler(_ notification: Notification) {

--- a/PlaybackLab/TVOSSwiftSampleApp/TVOSSwiftSampleApp/Players/FullscreenPlayerViewController.swift
+++ b/PlaybackLab/TVOSSwiftSampleApp/TVOSSwiftSampleApp/Players/FullscreenPlayerViewController.swift
@@ -20,8 +20,7 @@ class FullscreenPlayerViewController: OOOoyalaTVPlayerViewController {
                                            selector: #selector(notificationHandler(_:)),
                                            name: nil,
                                            object: player)
-    player.setEmbedCode(option.embedCode)
-    player.play()
+    player.setEmbedCode(option.embedCode, shouldAutoPlay: true, withCallback: nil)
   }
   
   @objc func notificationHandler(_ notification: Notification) {

--- a/PlaybackLab/TVOSSwiftSampleApp/TVOSSwiftSampleApp/Players/OoyalaPlayerTokenPlayerViewController.swift
+++ b/PlaybackLab/TVOSSwiftSampleApp/TVOSSwiftSampleApp/Players/OoyalaPlayerTokenPlayerViewController.swift
@@ -25,8 +25,7 @@ class OoyalaPlayerTokenPlayerViewController: OOOoyalaTVPlayerViewController, OOE
     player = OOOoyalaPlayer(pcode: option.pcode,
                             domain: OOPlayerDomain(string: option.domain),
                             embedTokenGenerator: self)
-    player.setEmbedCode(option.embedCode)
-    player.play()
+    player.setEmbedCode(option.embedCode, shouldAutoPlay: true, withCallback: nil)
   }
 
   func token(forEmbedCodes embedCodes: [String],


### PR DESCRIPTION
**Ticket goal:** Fix time labels and play/pause button when user performed seek to end
**How PR achieves the goal:** In this repo I just replaced deprecated methods about setEmbedCode. See changes in PR in `native-skin`
**Affected repo-s:** native-skin sdk + SampleApps
**Unit tests:** Unit test not added.
**SampleApp for testing**: mentioned in ticket description