### PR TITLE
[PLAYER-5819] ChromecastSampleApp crashing on trying to select an asset

### DIFF
--- a/ChromecastSampleApp/ChromecastSampleApp/Supporting Files/Info.plist
+++ b/ChromecastSampleApp/ChromecastSampleApp/Supporting Files/Info.plist
@@ -86,5 +86,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>App uses bluetooth for connecting with Chromecast device</string>
 </dict>
 </plist>

--- a/ChromecastSampleApp/ChromecastSampleApp/Supporting Files/Info.plist
+++ b/ChromecastSampleApp/ChromecastSampleApp/Supporting Files/Info.plist
@@ -53,14 +53,8 @@
 			</dict>
 		</dict>
 	</dict>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>audio</string>
-	</array>
-	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>App uses bluetooth for connection to Chromecast device</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>ooyala-slick-type.ttf</string>
@@ -69,6 +63,14 @@
 		<string>RobotoCondensed-Regular.ttf</string>
 		<string>RobotoCondensed-Bold.ttf</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
@@ -86,7 +88,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>App uses bluetooth for connecting with Chromecast device</string>
 </dict>
 </plist>


### PR DESCRIPTION
This app has crashed because it attempted to access privacy-sensitive data without a usage description.  The app's Info.plist must contain an NSBluetoothAlwaysUsageDescription key with a string value explaining to the user how the app uses this data.